### PR TITLE
PHP method access level errors  

### DIFF
--- a/src/Sanpi/Behatch/Context/DebugContext.php
+++ b/src/Sanpi/Behatch/Context/DebugContext.php
@@ -42,7 +42,7 @@ class DebugContext extends BaseContext
         }
     }
 
-    private function saveScreenshot($filename)
+    public function saveScreenshot($filename)
     {
         if (empty($filename)) {
             throw new \Exception('You must provide a filename for the screenshot.');

--- a/src/Sanpi/Behatch/Context/RestContext.php
+++ b/src/Sanpi/Behatch/Context/RestContext.php
@@ -154,7 +154,7 @@ class RestContext extends BaseContext
     /**
      * @see Behat\MinkExtension\Context\MinkContext::locatePath()
      */
-    protected function locatePath($path)
+    public function locatePath($path)
     {
         $startUrl = rtrim($this->getMinkParameter('base_url'), '/') . '/';
 


### PR DESCRIPTION
I found these errors actually while using behatch-skeleton

after following the install docs (without errors)

```
$ ./bin/behat --tags=github

Fatal error: Access level to Sanpi\Behatch\Context\DebugContext::saveScreenshot() must be public (as in class Behat\MinkExtension\Context\RawMinkContext) in /Users/sam/Projects/behatch-skeleton-orig/vendor/sanpi/behatch-contexts/src/Sanpi/Behatch/Context/DebugContext.php on line 59
```

==== then this error after fixing the one above =====

```
Fatal error: Access level to Sanpi\Behatch\Context\RestContext::locatePath() must be public (as in class Behat\MinkExtension\Context\RawMinkContext) in /Users/sam/Projects/behatch-skeleton-orig/vendor/sanpi/behatch-contexts/src/Sanpi/Behatch/Context/RestContext.php on line 164
```

fixing these issue with this commit, allowed success test of behatch-skeleton

```
$ ./bin/behat --tags=github

Feature: Github Feature

  @github
  Scenario: Is the github page still up ?                     # features/github.feature:7
    Given I am on "http://github.com/sanpii/behatch-skeleton" # Behat\MinkExtension\Context\MinkContext::visit()
    Then I should see "Behat Custom Helper"                   # Behat\MinkExtension\Context\MinkContext::assertPageContainsText()

  @github
  Scenario: I'm gonna check myself a bit                      # features/github.feature:12
    Given I am on "http://github.com/sanpii/behatch-skeleton" # Behat\MinkExtension\Context\MinkContext::visit()
    When I follow "features"                                  # Behat\MinkExtension\Context\MinkContext::clickLink()
    And I follow "github.feature"                             # Behat\MinkExtension\Context\MinkContext::clickLink()
    Then I should see "WE NEED TO GO DEEP !!"                 # Behat\MinkExtension\Context\MinkContext::assertPageContainsText()

2 scenarios (2 passed)
6 steps (6 passed)
0m2.52s
```
