### PR TITLE
MinkExtension locatePath access is now public

### DIFF
--- a/src/Sanpi/Behatch/Context/RestContext.php
+++ b/src/Sanpi/Behatch/Context/RestContext.php
@@ -154,7 +154,7 @@ class RestContext extends BaseContext
     /**
      * @see Behat\MinkExtension\Context\MinkContext::locatePath()
      */
-    protected function locatePath($path)
+    public function locatePath($path)
     {
         $startUrl = rtrim($this->getMinkParameter('base_url'), '/') . '/';
 


### PR DESCRIPTION
This patch simply updates the master branch to be in sync with the MinkExtension master branch. The access level for RestContext::locatePath needs changing to match these two commits:

https://github.com/Behat/MinkExtension/commit/7968dbc28688deacdf6ed1be2dd917d21bb2cce5
https://github.com/Behat/MinkExtension/commit/0f92203531851a014f7e5bac89b6bfbb42519594
