### PR TITLE
BrowserContext::iWaitSecondsUntilISeeInTheElement() not working

### DIFF
--- a/src/Sanpi/Behatch/Context/BaseContext.php
+++ b/src/Sanpi/Behatch/Context/BaseContext.php
@@ -31,6 +31,12 @@ abstract class BaseContext extends RawMinkContext implements TranslatedContextIn
         }
     }
 
+    protected function checkContains($expected, $actual, $message = null)
+    {
+        $regex   = '/'.preg_quote($expected, '/').'/ui';
+        return (bool)preg_match($regex, $actual);
+    }
+
     protected function assertNotContains($expected, $actual, $message = null)
     {
         $regex   = '/'.preg_quote($expected, '/').'/ui';

--- a/src/Sanpi/Behatch/Context/BrowserContext.php
+++ b/src/Sanpi/Behatch/Context/BrowserContext.php
@@ -175,28 +175,16 @@ class BrowserContext extends BaseContext
         else {
             $node = $element;
         }
-
         while ($time < $seconds) {
-            $actual   = $node->getText();
-            $e = null;
-
-            try {
-                $time++;
-                $this->assertContains($expected, $actual);
+            $actual = $node->getText();
+            $time++;
+            if($this->checkContains($expected, $actual)) {
+                return;
             }
-            catch (ExpectationException $e) {
-                if ($time >= $seconds) {
-                    $message = sprintf('The text "%s" was not found anywhere in the text of %s after a %s seconds timeout', $expected, $element, $seconds);
-                    throw new ResponseTextException($message, $this->getSession(), $e);
-                }
-            }
-
-            if ($e == null) {
-                break;
-            }
-
             sleep(1);
         }
+        $message = sprintf('The text "%s" was not found anywhere in the text of %s after a %s seconds timeout', $expected, $element, $seconds);
+        throw new ResponseTextException($message, $this->getSession());
     }
 
     /**


### PR DESCRIPTION
(At least as far as I can determine)

The Exception from $this->assertContains is caught upsteam in Definition::run()
the first time $this->assertContains is executed. Thus there is never a chance to retry after the sleep(1)

Not sure this fix is in quite the style of the rest os the code base, but regardless thought I would send it your way as it seems to be a bug.
