### PR TITLE
Removed non needed function which causes an error 

### DIFF
--- a/src/Sanpi/Behatch/Context/RestContext.php
+++ b/src/Sanpi/Behatch/Context/RestContext.php
@@ -151,14 +151,4 @@ class RestContext extends BaseContext
         );
     }
 
-    /**
-     * @see Behat\MinkExtension\Context\MinkContext::locatePath()
-     */
-    protected function locatePath($path)
-    {
-        $startUrl = rtrim($this->getMinkParameter('base_url'), '/') . '/';
-
-        return 0 !== strpos($path, 'http') ? $startUrl . ltrim($path, '/') : $path;
-    }
-
 }


### PR DESCRIPTION
It causes an error because his parent is public and it has been declared as private.
`Fatal error: Access level to Sanpi\Behatch\Context\RestContext::locatePath() must be public (as in class Behat\MinkExtension\Context\RawMinkContext) in /Volumes/Elao/workspace/declic-bo/vendor/sanpi/behatch-contexts/src/Sanpi/Behatch/Context/RestContext.php on line 164`

And the redefinition of this method is useless because the code is the same. So I removed it.
