### PR TITLE
Remove unused config param: debug.screen_id

### DIFF
--- a/behat.yml-dist
+++ b/behat.yml-dist
@@ -9,7 +9,6 @@ default:
                 browser: ~
                 debug:
                     screenshot_dir: "."
-                    screen_id: ":99.0"
                 system:
                     #root should never end up with /.
                     root: "."

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -132,7 +132,6 @@ Configuration
 * ``browser`` - more browser related steps (like mink)
 * ``debug`` - helper steps for debuging
     * ``screenshot_dir`` - the directory where store screenshots
-    * ``screen_id`` - then xorg screen id
 * ``system`` - shell related steps
     * ``root`` - the root directory of the filesystem
 * ``json`` - JSON related steps

--- a/src/Sanpi/Behatch/Extension.php
+++ b/src/Sanpi/Behatch/Extension.php
@@ -52,19 +52,6 @@ class Extension implements ExtensionInterface
                     );
                 }
             }
-            if (isset($values['screen_id'])) {
-                exec(sprintf("xdpyinfo -display %s >/dev/null 2>&1 && echo OK || echo KO", $values['screen_id']), $output);
-                if (sizeof($output) != 1 || $output[0] != "OK") {
-                    throw new \RuntimeException(
-                        'Screen id is not available.'
-                    );
-                }
-            }
-            else {
-                throw new \Exception(
-                    'You must provide a screen id.'
-                );
-            }
         }
     }
 
@@ -136,9 +123,6 @@ class Extension implements ExtensionInterface
                                 end()->
                                 scalarNode('screenshot_dir')->
                                     defaultValue('.')->
-                                end()->
-                                scalarNode('screen_id')->
-                                    defaultValue(':0')->
                                 end()->
                             end()->
                         end()->


### PR DESCRIPTION
The `debug.screen_id` is a remnant of the `1.2` version, that brought its own `saveScreenshot` version: https://github.com/sanpii/behatch-contexts/blob/1.2/src/Sanpi/Behatch/Context/DebugContext.php#L45-L58

Now the `DebugContext` uses the Mink built-in `saveScreenshot` method, and no longer use `import`, but the configuration and its validation still keep a trace of `screen_id`, which is no longer used.

This PR removes all traces of this unused configuration argument.
