### PR TITLE
Fixed logic for 'should not be in JSON'

### DIFF
--- a/src/Sanpi/Behatch/Context/JsonContext.php
+++ b/src/Sanpi/Behatch/Context/JsonContext.php
@@ -25,9 +25,12 @@ class JsonContext extends BaseContext
     {
         try {
             $this->getJson();
-            throw new \Exception("The response is in JSON");
         }
         catch (\Exception $e) {
+        }
+
+        if (!isset($e)) {
+            throw new \Exception("The response is in JSON");
         }
     }
 


### PR DESCRIPTION
The 'should not be in JSON' sentence never fails, because the throw is caught by the exception handler.

This change handles the success and failure of the JSON parsing, so that successful parsing of valid JSON causes an exception to be thrown, but unsuccessful parsing (bad JSON, non-JSON data, null data, etc) will bypass the throw.
