### PR TITLE
use statement missing

### DIFF
--- a/src/Sanpi/Behatch/Context/BrowserContext.php
+++ b/src/Sanpi/Behatch/Context/BrowserContext.php
@@ -6,6 +6,7 @@ use Behat\Behat\Context\Step;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\ResponseTextException;
+use Behat\Mink\Exception\ElementNotFoundException;
 
 class BrowserContext extends BaseContext
 {


### PR DESCRIPTION
To fix that fatal error:

```
Fatal error: Class 'Sanpi\Behatch\Context\ElementNotFoundException' not found in xxx/vendor/sanpi/behatch-contexts/src
/Sanpi/Behatch/Context/BrowserContext.php on line 377
```
