### PR TITLE
Suppress improper error from libxml

### DIFF
--- a/src/Sanpi/Behatch/Context/XmlContext.php
+++ b/src/Sanpi/Behatch/Context/XmlContext.php
@@ -130,12 +130,15 @@ class XmlContext extends BaseContext
 
         $dom = new \DomDocument();
         try {
-            $dom->loadXML($content);
-            $this->throwError();
+            $dom->strictErrorChecking = false;
+            $dom->validateOnParse = false;
+            $dom->loadXML($content, LIBXML_PARSEHUGE);
+            $this->throwError($dom);
         }
         catch(\DOMException $e) {
             throw new \RuntimeException($e->getMessage());
         }
+
         return $dom;
     }
 
@@ -143,7 +146,9 @@ class XmlContext extends BaseContext
     {
         $error = libxml_get_last_error();
         if (!empty($error)) {
-            throw new \DomException($error->message . ' at line ' . $error->line);
+            if ($error->message != 'Validation failed: no DTD found !') {
+                throw new \DomException($error->message . ' at line ' . $error->line);
+            }
         }
     }
 }


### PR DESCRIPTION
Some versions of libxml generate improper errors during parsing.  This causes otherwise well-formed XML handling to fail.  There are many, many bug reports about this issue.  Here are a random sample:
- https://groups.google.com/forum/?fromgroups=#!topic/silex-php/EVAHWTfibwo
- https://github.com/symfony/symfony/issues/7291#issuecomment-14563561
- http://www.php.net/manual/en/domdocument.validate.php#99818
- https://bugs.php.net/bug.php?id=46465
- http://trac.symfony-project.org/ticket/9999
- http://forum.pivotx.net/viewtopic.php?f=17&t=3278

This specific fix sets the Dom::loadXML() method up to ignore parsing validation explicitly, and then filters for the erroneous error message generated from the "bad" versions of libxml : "Validation failed: no DTD found !".
