### PR TITLE
Corrected grammar for REST "should contain" sentence

### DIFF
--- a/features/rest.feature
+++ b/features/rest.feature
@@ -2,7 +2,7 @@ Feature: Testing RESTContext
 
     Scenario: Testing headers
         When I send a GET request to "rest/index.php"
-        And the header "Content-Type" should be contains "text"
+        And the header "Content-Type" should contain "text"
         And the header "Content-Type" should be equal to "text/html"
         And the header "Content-Type" should not contain "text/json"
         And the header "xxx" should not exist
@@ -48,7 +48,7 @@ Feature: Testing RESTContext
         https://tools.ietf.org/html/rfc2616#section-4.2
 
         When I send a GET request to "rest/index.php"
-        Then the header "content-type" should be contains "text"
+        Then the header "content-type" should contain "text"
 
     Scenario: Debug
         Given I add "xxx" header equal to "yyy"

--- a/i18n/fr.xliff
+++ b/i18n/fr.xliff
@@ -214,7 +214,7 @@
                 <target><![CDATA[/^(?:|j')ajoute l'entête "(?P<name>[^"]*)" égale à "(?P<value>[^"]*)"$/]]></target>
             </trans-unit>
             <trans-unit id="the-header-should-be-contains">
-                <source><![CDATA[/^the header "(?P<name>[^"]*)" should be contains "(?P<value>[^"]*)"$/]]></source>
+                <source><![CDATA[/^the header "(?P<name>[^"]*)" should contain "(?P<value>[^"]*)"$/]]></source>
                 <target><![CDATA[/^l'entête "(?P<name>[^"]*)" devrait contenir "(?P<value>[^"]*)"$/]]></target>
             </trans-unit>
             <trans-unit id="the-header-should-not-contain">

--- a/i18n/ja.xliff
+++ b/i18n/ja.xliff
@@ -181,7 +181,7 @@
                 <target><![CDATA[/^(?:|私が)"(?P<name>[^"]*)"ヘッダに"(?P<value>[^"]*)"を追加する$/u]]></target>
             </trans-unit>
             <trans-unit id="the-header-should-be-contains">
-                <source><![CDATA[/^the header "(?P<name>[^"]*)" should be contains "(?P<value>[^"]*)"$/]]></source>
+                <source><![CDATA[/^the header "(?P<name>[^"]*)" should contain "(?P<value>[^"]*)"$/]]></source>
                 <target><![CDATA[/^"(?P<name>[^"]*)"ヘッダが"(?P<value>[^"]*)"を含むこと$/u]]></target>
             </trans-unit>
             <trans-unit id="the-header-should-not-contain">

--- a/src/Sanpi/Behatch/Context/RestContext.php
+++ b/src/Sanpi/Behatch/Context/RestContext.php
@@ -98,12 +98,13 @@ class RestContext extends BaseContext
     /**
      * Checks, whether the header name contains the given text
      *
+     * @Then /^the header "(?P<name>[^"]*)" should contain "(?P<value>[^"]*)"$/
      * @Then /^the header "(?P<name>[^"]*)" should be contains "(?P<value>[^"]*)"$/
      */
     public function theHeaderShouldBeContains($name, $value)
     {
         $this->assertContains($value, $this->getHttpHeader($name),
-            sprintf('The header "%s" is doesn\'t contain to "%s"', $name, $value)
+            sprintf('The header "%s" doesn\'t contain "%s"', $name, $value)
         );
     }
 
@@ -171,7 +172,7 @@ class RestContext extends BaseContext
         }
 
         return array(
-            new Step\Then('the header "Content-Type" should be contains "charset=' . $encoding . '"'),
+            new Step\Then('the header "Content-Type" should contain "charset=' . $encoding . '"'),
         );
     }
 


### PR DESCRIPTION
Minor corrections of the grammar for "should contain" for REST context.

Updated the translation files with the modified "should contain" regex - original translations assumed correct and simply duplicated from the original regex.

Also updated the test features to reflect the updated grammar.
