### PR TITLE
Added 'print last XML response' sentence

### DIFF
--- a/features/xml.feature
+++ b/features/xml.feature
@@ -15,6 +15,8 @@ Feature: Testing XmlContext
         Then the response should be in XML
         When I am on "/xml/country.xml"
         Then the response should be in XML
+        When I am on "/xml/needsformatting.xml"
+        Then the response should be in XML
         When I am on "/xml/imnotaxml.xml"
         Then the response should not be in XML
         When I am on "/xml/notfound.xml"
@@ -116,3 +118,7 @@ Feature: Testing XmlContext
           And the XML attribute "id" on element "//people/p:person[@id=2]" should not be equal to "4"
           And the XML attribute "name" on element "//people/p:person[@id=3]" should exist
           And the XML attribute "size" on element "//people/p:person[@id=1]/items/item" should not exist
+
+    Scenario: Pretty print xml
+       Given I am on "/xml/needsformatting.xml"
+         And print last XML response

--- a/fixtures/www/xml/needsformatting.xml
+++ b/fixtures/www/xml/needsformatting.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" standalone="yes"?>
+<wibble xmlns:w="http://example.org/ns"><w:wibbler name="John"><w:kersplang /></w:wibbler>
+                <w:wibbler name="Max"><w:kersplang noisy="very"> </w:kersplang></w:wibbler><w:wibbler name="Roberta"><w:kersplang noisy="early"> </w:kersplang></w:wibbler>
+<w:wibbler name="Axel"><w:kersplang noisy="nope" /></w:wibbler><w:wibbler name="Vald"><w:kersplang noisy="tomorrow" /><difficulty level="4" /></w:wibbler>
+    <w:wibbler
+  name="Ariel"><w:kersplang noisy="yes" /></w:wibbler      >
+
+
+<w:wibbler
+name="Axel"><w:kersplang noisy
+                     ="deafening"><difficulty     level= "expert" /></w:kersplang>
+</w:wibbler         ></wibble>

--- a/src/Sanpi/Behatch/Context/XmlContext.php
+++ b/src/Sanpi/Behatch/Context/XmlContext.php
@@ -238,6 +238,19 @@ class XmlContext extends BaseContext
     }
 
     /**
+     * Optimistically (ignoring errors) attempt to pretty-print the last XML response
+     *
+     * @Then /^print last XML response$/
+     */
+    public function printLastXmlResponse()
+    {
+        $dom = $this->getDom(false, false);
+        $dom->formatOutput = true;
+        $content = $dom->saveXML();
+        $this->printDebug($content);
+    }
+
+    /**
      * @param string $element
      * @return \DomNodeList
      */
@@ -411,10 +424,11 @@ class XmlContext extends BaseContext
 
     /**
      * @param bool $throwExceptions
+     * @param bool $preserveWhitespace
      * @return \DomDocument
      * @throws \RuntimeException
      */
-    private function getDom($throwExceptions)
+    private function getDom($throwExceptions, $preserveWhitespace = true)
     {
         $content = $this->getSession()->getPage()->getContent();
 
@@ -422,6 +436,7 @@ class XmlContext extends BaseContext
         try {
             $dom->strictErrorChecking = false;
             $dom->validateOnParse = false;
+            $dom->preserveWhiteSpace = $preserveWhitespace;
             $dom->loadXML($content, LIBXML_PARSEHUGE);
             $this->throwError();
         }


### PR DESCRIPTION
Added a new sentence for 'print last XML response' that corresponds to the JSON sentence 'print last JSON response'.

The printed response is formatted for readability - to print the exact response, the sentence 'print last response' is the solution.

Also added new test fixture file to test output formatting.
