### PR TITLE
Fix spelling for 'create file containing' sentence

### DIFF
--- a/features/system.feature
+++ b/features/system.feature
@@ -7,7 +7,7 @@ Feature: System feature
         Given I execute "bin/behat --help"
 
     Scenario: File creation
-        When I create the file "fixtures/test" contening:
+        When I create the file "fixtures/test" containing:
         """
         A new file
         """

--- a/i18n/fr.xliff
+++ b/i18n/fr.xliff
@@ -130,7 +130,7 @@
                 <target><![CDATA[/^(?:|j')exécute "(?P<command>[^"]*)" depuis la racine du projet$/]]></target>
             </trans-unit>
             <trans-unit id="i-create-the-file-contening">
-                <source><![CDATA[/^(?:|I )create the file "(?P<filename>[^"]*)" contening:$/]]></source>
+                <source><![CDATA[/^(?:|I )create the file "(?P<filename>[^"]*)" containing:$/]]></source>
                 <target><![CDATA[/^(?:|je )crée le fichier "(?P<filename>[^"]*)" contenant :$/]]></target>
             </trans-unit>
             <trans-unit id="print-the-content-of-file">

--- a/src/Sanpi/Behatch/Context/SystemContext.php
+++ b/src/Sanpi/Behatch/Context/SystemContext.php
@@ -51,9 +51,10 @@ class SystemContext extends BaseContext
     }
 
     /**
+     * @Given /^(?:|I )create the file "(?P<filename>[^"]*)" containing:$/
      * @Given /^(?:|I )create the file "(?P<filename>[^"]*)" contening:$/
      */
-    public function iCreateTheFileContening($filename, PyStringNode $string)
+    public function iCreateTheFileContaining($filename, PyStringNode $string)
     {
         if (!is_file($filename)) {
             file_put_contents($filename, $string);


### PR DESCRIPTION
Simple fixes for the spelling of 'container'.

Updated the French translation, but the Japanese translation file did not have an entry.
