### PR TITLE
Made private methods protected for context classes

### DIFF
--- a/src/Sanpi/Behatch/Context/JsonContext.php
+++ b/src/Sanpi/Behatch/Context/JsonContext.php
@@ -186,7 +186,7 @@ class JsonContext extends BaseContext
         $this->printDebug($content);
     }
 
-    private function evaluateJson($json, $expression)
+    protected function evaluateJson($json, $expression)
     {
         if ($this->getParameter('json', 'evaluation_mode') === 'javascript') {
             $expression = str_replace('.', '->', $expression);
@@ -208,7 +208,7 @@ class JsonContext extends BaseContext
         return $result;
     }
 
-    private function validate($schema)
+    protected function validate($schema)
     {
         try {
             $jsonSchema = $this->decode($schema);
@@ -228,14 +228,14 @@ class JsonContext extends BaseContext
         }
     }
 
-    private function getJson()
+    protected function getJson()
     {
         $content = $this->getSession()->getPage()->getContent();
 
         return $this->decode($content);
     }
 
-    private function decode($content)
+    protected function decode($content)
     {
         $result = json_decode($content);
 
@@ -246,7 +246,7 @@ class JsonContext extends BaseContext
         return $result;
     }
 
-    private function encode($content)
+    protected function encode($content)
     {
         $json = null;
 

--- a/src/Sanpi/Behatch/Context/RestContext.php
+++ b/src/Sanpi/Behatch/Context/RestContext.php
@@ -225,7 +225,7 @@ class RestContext extends BaseContext
         $this->printDebug($command);
     }
 
-    private function getHttpHeader($name)
+    protected function getHttpHeader($name)
     {
         $name = strtolower($name);
         $header = $this->getHttpHeaders();
@@ -246,7 +246,7 @@ class RestContext extends BaseContext
         return $value;
     }
 
-    private function getHttpHeaders()
+    protected function getHttpHeaders()
     {
         return array_change_key_case(
             $this->getSession()->getResponseHeaders(),

--- a/src/Sanpi/Behatch/Context/XmlContext.php
+++ b/src/Sanpi/Behatch/Context/XmlContext.php
@@ -287,7 +287,7 @@ class XmlContext extends BaseContext
      * @param \DomDocument $dom
      * @return \SimpleXMLElement
      */
-    private function getSimpleXml(\DOMDocument $dom = null)
+    protected function getSimpleXml(\DOMDocument $dom = null)
     {
         return simplexml_import_dom($dom ? $dom : $this->getDom(false));
     }
@@ -296,7 +296,7 @@ class XmlContext extends BaseContext
      * @param \DOMDocument $dom
      * @return array
      */
-    private function getNamespaces(\DOMDocument $dom = null)
+    protected function getNamespaces(\DOMDocument $dom = null)
     {
         $xml = $this->getSimpleXml($dom);
         $namespaces = $xml->getNamespaces(true);
@@ -354,7 +354,7 @@ class XmlContext extends BaseContext
         $this->schemaValidate($dom, $xsd->getRaw());
     }
 
-    private function schemaValidate(\DomDocument $dom, $xsd)
+    protected function schemaValidate(\DomDocument $dom, $xsd)
     {
         try {
             $dom->schemaValidateSource($xsd);
@@ -391,7 +391,7 @@ class XmlContext extends BaseContext
         $this->relaxNGValidate($dom, $ng->getRaw());
     }
 
-    private function relaxNGValidate(\DomDocument $dom, $ng)
+    protected function relaxNGValidate(\DomDocument $dom, $ng)
     {
         try {
             $dom->relaxNGValidateSource($ng);
@@ -428,7 +428,7 @@ class XmlContext extends BaseContext
      * @return \DomDocument
      * @throws \RuntimeException
      */
-    private function getDom($throwExceptions, $preserveWhitespace = true)
+    protected function getDom($throwExceptions, $preserveWhitespace = true)
     {
         $content = $this->getSession()->getPage()->getContent();
 
@@ -449,7 +449,7 @@ class XmlContext extends BaseContext
         return $dom;
     }
 
-    private function throwError()
+    protected function throwError()
     {
         $error = libxml_get_last_error();
         if (!empty($error)) {


### PR DESCRIPTION
I needed to add some custom JSON steps, and when I extended the `JsonContext` class, didn't then have visibility of the private methods, so switching to protected to make extensible.
