### PR TITLE
urlencode the scenario name

### DIFF
--- a/src/Sanpi/Behatch/Context/DebugContext.php
+++ b/src/Sanpi/Behatch/Context/DebugContext.php
@@ -39,7 +39,7 @@ class DebugContext extends BaseContext
     {
         if ($event->getResult() == StepEvent::FAILED) {
             $path = $this->getParameter('debug', 'screenshot_dir');
-            $scenarioName = str_replace(' ', '_', $event->getStep()->getParent()->getTitle());
+            $scenarioName = urlencode(str_replace(' ', '_', $event->getStep()->getParent()->getTitle()));
             $filename = sprintf('fail_%s_%s.png', time(), $scenarioName);
             $this->saveScreenshot($filename, $path);
         }


### PR DESCRIPTION
Currently you get an error when saving screenshots for scenarios that contain certain characters in their name, such as forward slash or comma. These can be urlencoded to avoid this error and to facilitate browsing the screenshots in a browser.
