### PR TITLE
Update mink-extension requirement to stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "behat/behat": "3.*",
         "behat/mink": "*",
-        "behat/mink-extension": "2.0.x-dev",
+        "behat/mink-extension": "~2.0",
         "justinrainbow/json-schema": "*",
         "symfony/property-access": "~2.3"
     },


### PR DESCRIPTION
MinkExtension has now a stable 2.0.0 tag, see https://github.com/Behat/MinkExtension/tree/v2.0.0
