### PR TITLE
Throw exception on json inspector invalid index

### DIFF
--- a/src/Json/JsonInspector.php
+++ b/src/Json/JsonInspector.php
@@ -16,7 +16,9 @@ class JsonInspector
     public function __construct($evaluationMode)
     {
         $this->evaluationMode = $evaluationMode;
-        $this->accessor = PropertyAccess::createPropertyAccessor();
+        $this->accessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->enableExceptionOnInvalidIndex()
+            ->getPropertyAccessor();
     }
 
     public function evaluate(Json $json, $expression)

--- a/tests/units/Json/JsonInspector.php
+++ b/tests/units/Json/JsonInspector.php
@@ -15,7 +15,6 @@ class JsonInspector extends atoum
     {
         $this
             ->given(
-                $accessor = new \Symfony\Component\PropertyAccess\PropertyAccessor,
                 $json = new \mock\Sanpi\Behatch\Json\Json('{}'),
                 $json->getMockController()->read = 'foobar'
             )
@@ -30,7 +29,7 @@ class JsonInspector extends atoum
 
                 ->mock($json)
                     ->call('read')
-                    ->withArguments('foo.bar', $accessor)
+                    ->withArguments('foo.bar')
                     ->once()
         ;
     }
@@ -56,7 +55,6 @@ class JsonInspector extends atoum
     {
         $this
             ->given(
-                $accessor = new \Symfony\Component\PropertyAccess\PropertyAccessor,
                 $json = new \mock\Sanpi\Behatch\Json\Json('{}'),
                 $json->getMockController()->read = 'foobar'
             )
@@ -71,7 +69,7 @@ class JsonInspector extends atoum
 
                 ->mock($json)
                     ->call('read')
-                    ->withArguments('foo.bar', $accessor)
+                    ->withArguments('foo.bar')
                     ->once()
         ;
     }
@@ -80,7 +78,6 @@ class JsonInspector extends atoum
     {
         $this
             ->given(
-                $accessor = new \Symfony\Component\PropertyAccess\PropertyAccessor,
                 $json = new \mock\Sanpi\Behatch\Json\Json('{}'),
                 $json->getMockController()->read = 'foobar'
             )
@@ -95,7 +92,7 @@ class JsonInspector extends atoum
 
                 ->mock($json)
                     ->call('read')
-                    ->withArguments('foo->bar', $accessor)
+                    ->withArguments('foo->bar')
                     ->once()
         ;
     }


### PR DESCRIPTION
By default the `PropertyAccessor` won't throw an exception on invalid index, which breaks this step : https://github.com/sanpii/behatch-contexts/blob/master/src/Context/JsonContext.php#L130

This PR fixes this.
