### PR TITLE
Fix multiple values headers

### DIFF
--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -236,7 +236,7 @@ class RestContext extends BaseContext
 
         if (isset($header[$name])) {
             if (is_array($header[$name])) {
-                $value = $header[$name][0];
+                $value = implode(', ', $header[$name]);
             }
             else {
                 $value = $header[$name];


### PR DESCRIPTION
For example the `Vary: Accept-Encoding, Accept-Language` header is represented by : 
array(0 => 'Accept-Encoding', 1 => 'Accept-Language').

So returning `$header[$name][0]` is incorrect.
