### PR TITLE
Decouple JsonContext from Mink

### DIFF
--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -7,14 +7,19 @@ use Behat\Gherkin\Node\PyStringNode;
 use Sanpi\Behatch\Json\Json;
 use Sanpi\Behatch\Json\JsonSchema;
 use Sanpi\Behatch\Json\JsonInspector;
+use Sanpi\Behatch\HttpCall\HttpCallResultAware;
+use Sanpi\Behatch\HttpCall\HttpCallResultPool;
 
 class JsonContext extends BaseContext
 {
     private $inspector;
 
-    public function __construct($evaluationMode = 'javascript')
+    private $httpCallResultPool;
+
+    public function __construct($evaluationMode = 'javascript', HttpCallResultPool $httpCallResultPool)
     {
         $this->inspector = new JsonInspector($evaluationMode);
+        $this->httpCallResultPool = $httpCallResultPool;
     }
 
     /**
@@ -204,8 +209,6 @@ class JsonContext extends BaseContext
 
     private function getJson()
     {
-        $content = $this->getSession()->getPage()->getContent();
-
-        return new Json($content);
+        return new Json($this->httpCallResultPool->getResult()->getValue());
     }
 }

--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -23,6 +23,8 @@ class RestContext extends BaseContext
 
         $client->request($method, $this->locatePath($url));
         $client->followRedirects(true);
+
+        return $this->getSession()->getPage();
     }
 
     /**
@@ -52,6 +54,8 @@ class RestContext extends BaseContext
 
         $client->request($method, $this->locatePath($url), $parameters);
         $client->followRedirects(true);
+
+        return $this->getSession()->getPage();
     }
 
     /**
@@ -69,6 +73,8 @@ class RestContext extends BaseContext
         $client->request($method, $this->locatePath($url),
             array(), array(), array(), $body->getRaw());
         $client->followRedirects(true);
+
+        return $this->getSession()->getPage();
     }
 
     /**

--- a/src/HttpCall/ContextSupportedVoter.php
+++ b/src/HttpCall/ContextSupportedVoter.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+interface ContextSupportedVoter
+{
+    public function vote(HttpCallResult $httpCallResult);
+}

--- a/src/HttpCall/ContextSupportedVoters.php
+++ b/src/HttpCall/ContextSupportedVoters.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+class ContextSupportedVoters implements ContextSupportedVoter
+{
+    private $voters;
+
+    public function __construct(array $voters = array())
+    {
+        foreach ($voters as $voter) {
+            $this->register($voter);
+        }
+    }
+
+    public function register(ContextSupportedVoter $voter)
+    {
+        $this->voters[] = $voter;
+    }
+
+    public function vote(HttpCallResult $httpCallResult)
+    {
+        foreach ($this->voters as $voter) {
+            if ($voter->vote($httpCallResult)) {
+                if ($voter instanceof FilterableHttpCallResult) {
+                    $httpCallResult->update($voter->filter($httpCallResult));
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/HttpCall/FilterableHttpCallResult.php
+++ b/src/HttpCall/FilterableHttpCallResult.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+interface FilterableHttpCallResult
+{
+    public function filter(HttpCallResult $httpCallResult);
+}

--- a/src/HttpCall/HttpCallListener.php
+++ b/src/HttpCall/HttpCallListener.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+use Behat\Behat\EventDispatcher\Event\StepTested;
+use Behat\Behat\EventDispatcher\Event\AfterStepTested;
+use Behat\Behat\Tester\Result\ExecutedStepResult;
+use Behat\Mink\Mink;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class HttpCallListener implements EventSubscriberInterface
+{
+    private $contextSupportedVoter;
+
+    private $httpCallResultPool;
+
+    private $mink;
+
+    public function __construct(ContextSupportedVoter $contextSupportedVoter, HttpCallResultPool $httpCallResultPool, Mink $mink)
+    {
+        $this->contextSupportedVoter = $contextSupportedVoter;
+        $this->httpCallResultPool = $httpCallResultPool;
+        $this->mink = $mink;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+           StepTested::AFTER => 'afterStep'
+        );
+    }
+
+    public function afterStep(AfterStepTested $event)
+    {
+        $testResult = $event->getTestResult();
+
+        if (!$testResult instanceof ExecutedStepResult) {
+            return;
+        }
+
+        $httpCallResult = new HttpCallResult(
+            $testResult->getCallResult()->getReturn()
+        );
+
+        if ($this->contextSupportedVoter->vote($httpCallResult)) {
+            $this->httpCallResultPool->store($httpCallResult);
+
+            return true;
+        }
+
+        // For now to avoid modification on MinkContext
+        // We add fallback on Mink
+        try {
+            $this->httpCallResultPool->store(
+                new HttpCallResult($this->mink->getSession()->getPage()->getContent())
+            );
+        } catch (\LogicException $e) {
+            // Mink has no response
+        }
+    }
+}

--- a/src/HttpCall/HttpCallResult.php
+++ b/src/HttpCall/HttpCallResult.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+class HttpCallResult
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function update($value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/HttpCall/HttpCallResultPool.php
+++ b/src/HttpCall/HttpCallResultPool.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+class HttpCallResultPool
+{
+    private $result;
+
+    public function store(HttpCallResult $result)
+    {
+        $this->result = $result;
+    }
+
+    public function getResult()
+    {
+        return $this->result;
+    }
+}

--- a/src/HttpCall/HttpCallResultPoolResolver.php
+++ b/src/HttpCall/HttpCallResultPoolResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+use Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler;
+use Behat\Behat\Context\Argument\ArgumentResolver;
+
+use Sanpi\Behatch\HttpCall\HttpCallResultPool;
+
+class HttpCallResultPoolResolver implements ArgumentResolver
+{
+    private $httpCallResultPool;
+
+    public function __construct(HttpCallResultPool $httpCallResultPool)
+    {
+        $this->httpCallResultPool = $httpCallResultPool;
+    }
+
+    public function resolveArguments(\ReflectionClass $classReflection, array $arguments)
+    {
+        $constructor = $classReflection->getConstructor();
+        if ($constructor !== null) {
+            $parameters = $constructor->getParameters();
+            foreach ($parameters as $parameter) {
+                if (null !== $parameter->getClass() && $parameter->getClass()->name === 'Sanpi\\Behatch\\HttpCall\\HttpCallResultPool') {
+                    $arguments[$parameter->name] = $this->httpCallResultPool;
+                }
+            }
+        }
+        return $arguments;
+    }
+}

--- a/src/HttpCall/RestContextVoter.php
+++ b/src/HttpCall/RestContextVoter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+class RestContextVoter implements ContextSupportedVoter, FilterableHttpCallResult
+{
+    public function vote(HttpCallResult $httpCallResult)
+    {
+        return $httpCallResult->getValue() instanceof \Behat\Mink\Element\DocumentElement;
+    }
+
+    public function filter(HttpCallResult $httpCallResult)
+    {
+        return $httpCallResult->getValue()->getContent();
+    }
+}

--- a/src/Resources/services/http_call.yml
+++ b/src/Resources/services/http_call.yml
@@ -1,0 +1,23 @@
+services:
+    behatch.http_call.listener:
+        class: Sanpi\Behatch\HttpCall\HttpCallListener
+        arguments: [@behatch.context_supported.voter, @behatch.http_call.result_pool, @mink]
+        tags:
+            - { name: event_dispatcher.subscriber, priority: 0 }
+
+    behatch.http_call.result_pool:
+        class: Sanpi\Behatch\HttpCall\HttpCallResultPool
+
+    behatch.context_supported.voter:
+        class: Sanpi\Behatch\HttpCall\ContextSupportedVoters
+
+    behatch.rest_context_supported.voter:
+        class: Sanpi\Behatch\HttpCall\RestContextVoter
+        tags:
+            - { name: behatch.context_voter }
+
+    behatch.http_call.argument_resolver:
+        class: Sanpi\Behatch\HttpCall\HttpCallResultPoolResolver
+        arguments: [@behatch.http_call.result_pool]
+        tags:
+            - { name: context.argument_resolver }


### PR DESCRIPTION
In order to use JsonContext without mink session (with guzzle for example) we need to let JsonContext fetch the JSON from anything we want.

The idea is to set a listener after each step which listen the result returned by the step.

So for example RestContext returns now the session content : 
https://github.com/tyx/behatch-contexts/commit/1849a3bf94159bb231e05064eacb0cf2ebcb5794#diff-c719e0fc3488be1d7970588ac4102d9cR27

And we inject it in JsonContext because of : 
https://github.com/tyx/behatch-contexts/commit/1849a3bf94159bb231e05064eacb0cf2ebcb5794#diff-b4feec5363c8f57c2d3b10586a532d63R1

So it is not BC Break as I add a very last fallback on mink for now.
