### PR TITLE
Update the integer casting to avoid matching trailing 0

### DIFF
--- a/src/Context/BaseContext.php
+++ b/src/Context/BaseContext.php
@@ -16,7 +16,7 @@ abstract class BaseContext extends RawMinkContext implements TranslatableContext
     }
 
     /**
-     * @transform /^(\d+)(?:st|nd|rd|th)?$/
+     * @transform /^(0|[1-9]\d*)(?:st|nd|rd|th)?$/
      */
     public function castToInt($count)
     {


### PR DESCRIPTION
A numeric string starting with a 0 should not be casted to an integer as this is loosing some chars. This is causing issues for some cases, for instance when entering a phone number in a field

See https://groups.google.com/forum/#!topic/behat/cMnWNMS8A3Q for a report about this
