### PR TITLE
Fix multidimensional request parameters

### DIFF
--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -47,8 +47,10 @@ class RestContext extends BaseContext
                 $row['value'] = '@'.rtrim($this->getMinkParameter('files_path'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.substr($row['value'],1);
             }
 
-            $parameters[$row['key']] = $row['value'];
+            $parameters[] = sprintf('%s=%s', $row['key'], $row['value']);
         }
+
+        parse_str(implode('&', $parameters), $parameters);
 
         $client->request($method, $this->locatePath($url), $parameters);
         $client->followRedirects(true);


### PR DESCRIPTION
This PR fixes multidimensional request parameters. For example, these parameters give : 

```
| password[first]  | test |
| password[second] | test |
```

**Before**
`array('password[first]' => 'test', 'password[second]' => 'test')`

**After**
`array('password' => array('first' => 'test, 'second' => 'test))`
