### PR TITLE
Add test on ability to check json payload against json schema

### DIFF
--- a/features/json.feature
+++ b/features/json.feature
@@ -72,6 +72,43 @@ Feature: Testing JSONContext
             }
             """
 
+    Scenario: Json validation deep
+        Given I am on "/json/booking.json"
+        Then the JSON should be invalid according to this schema:
+            """
+            {
+                "type":"object",
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "required":false,
+                "properties":{
+                    "Booking": {
+                        "type":"object",
+                        "required":false
+                    },
+                    "Metadata": {
+                        "type":"object",
+                        "required":false,
+                        "properties":{
+                            "First": {
+                                "type":"object",
+                                "required":false,
+                                "properties":{
+                                    "default_value": {
+                                        "type":"boolean",
+                                        "required":false
+                                    },
+                                    "enabled": {
+                                        "type":"boolean",
+                                        "required":true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+
     Scenario: Json contents validation
         Given I am on "/json/imajson.json"
         Then the JSON should be equal to:

--- a/fixtures/www/json/booking.json
+++ b/fixtures/www/json/booking.json
@@ -1,0 +1,12 @@
+{
+    "Booking": {
+        "id": "1",
+        "price": "77.21"
+    }, "Metadata":
+    {
+        "First":  {
+            "bad_property_name": true,
+            "default_value": true
+        }
+    }
+}

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -4,6 +4,7 @@ namespace Sanpi\Behatch\Context;
 
 use Behat\Gherkin\Node\PyStringNode;
 
+use Behat\Mink\Exception\ExpectationException;
 use Sanpi\Behatch\Json\Json;
 use Sanpi\Behatch\Json\JsonSchema;
 use Sanpi\Behatch\Json\JsonInspector;
@@ -156,6 +157,26 @@ class JsonContext extends BaseContext
             $this->getJson(),
             new JsonSchema($schema)
         );
+    }
+
+    /**
+     * @Then the JSON should be invalid according to this schema:
+     */
+    public function theJsonShouldBeInvalidAccordingToThisSchema(PyStringNode $schema)
+    {
+        try {
+            $isValid = $this->inspector->validate(
+                $this->getJson(),
+                new JsonSchema($schema)
+            );
+
+        } catch (\Exception $e) {
+            $isValid = false;
+        }
+
+        if (true === $isValid) {
+            throw new ExpectationException('Expected to receive invalid json, got valid one', $this->getSession());
+        }
     }
 
     /**

--- a/src/Json/Json.php
+++ b/src/Json/Json.php
@@ -6,7 +6,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class Json
 {
-    private $content;
+    protected $content;
 
     public function __construct($content)
     {


### PR DESCRIPTION
Hi

Currently when we use `@Then the JSON should be valid according to this schema:` step, the JSON payload is not validated against the given schema.

Here is the test highlighting the issue with the **fix**.

Keep up the good work
