### PR TITLE
Fix json schema validation

### DIFF
--- a/src/Json/Json.php
+++ b/src/Json/Json.php
@@ -13,6 +13,11 @@ class Json
         $this->content = $this->decode((string) $content);
     }
 
+    public function getContent()
+    {
+        return $this->content;
+    }
+
     public function read($expression, PropertyAccessor $accessor)
     {
         if (is_array($this->content)) {

--- a/src/Json/JsonSchema.php
+++ b/src/Json/JsonSchema.php
@@ -28,7 +28,7 @@ class JsonSchema extends Json
 
     public function validate(Json $json, Validator $validator)
     {
-        $validator->check($json, $this);
+        $validator->check($json->getContent(), $this->getContent());
 
         if (!$validator->isValid()) {
             $msg = "JSON does not validate. Violations:".PHP_EOL;

--- a/tests/units/Json/JsonSchema.php
+++ b/tests/units/Json/JsonSchema.php
@@ -60,7 +60,7 @@ class JsonSchema extends atoum
             )
                 ->mock($validator)
                     ->call('check')
-                    ->withArguments($json, $schema)
+                    ->withArguments($json->getContent(), $schema->getContent())
                     ->once()
 
                 ->boolean($result)


### PR DESCRIPTION
Currently `Sanpi\Behatch\Json\Json` and ```Sanpi\Behatch\Json\JsonSchema` objects are given to the `JsonSchema\Validator::check` method.

It think this is incorrect as it should be the `content` value of this objects that should be used.

This PR fixes this.
