### PR TITLE
Deal with missing Mink

### DIFF
--- a/src/HttpCall/HttpCallListener.php
+++ b/src/HttpCall/HttpCallListener.php
@@ -56,6 +56,8 @@ class HttpCallListener implements EventSubscriberInterface
             );
         } catch (\LogicException $e) {
             // Mink has no response
+        } catch (\Behat\Mink\Exception\DriverException $e) {
+            // No Mink
         }
     }
 }


### PR DESCRIPTION
As we could now use JsonContext without RestContext, we should suppose that mink is not always defined
