### PR TITLE
Handling exception UnexpectedAlertOpen thrown when browser displays an alert

### DIFF
--- a/src/HttpCall/HttpCallListener.php
+++ b/src/HttpCall/HttpCallListener.php
@@ -7,6 +7,7 @@ use Behat\Behat\EventDispatcher\Event\AfterStepTested;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
 use Behat\Mink\Mink;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use WebDriver\Exception\UnexpectedAlertOpen;
 
 class HttpCallListener implements EventSubscriberInterface
 {
@@ -58,6 +59,8 @@ class HttpCallListener implements EventSubscriberInterface
             // Mink has no response
         } catch (\Behat\Mink\Exception\DriverException $e) {
             // No Mink
+        } catch (UnexpectedAlertOpen $e) {
+           // alert modal on screen - driver will refuse any interactions
         }
     }
 }


### PR DESCRIPTION
Sadly there are projects that are still using native js alerts. I've noticed that when browser shows an alert, I don't have any chance to interact to the modal because an exception is raised by HttpCallListener.

These steps worked few weeks ago.

```
    When I go to subscription details page
    And wait 10 seconds until I see "Subscription Details"
    # this step will show a js alert
    And I follow "Cancel subscription"
   # this step will assert the message and accept it
    And I accept subscription cancel alert
```
