### PR TITLE
Improve json context

### DIFF
--- a/features/json.feature
+++ b/features/json.feature
@@ -153,3 +153,8 @@ Feature: Testing JSONContext
         Given I am on "/json/withdoublequote.json"
         Then the response should be in JSON
         And the JSON node "foo" should be equal to "A "bar" in a bar"
+
+    Scenario: Json Schema validation
+        Given I am on "/json/imajson.json"
+        And the JSON node "object[0]" should be valid according to the schema "fixtures/www/jsonschema/object.schema.json"
+        And the JSON node "object[1]" should not be valid according to the schema "fixtures/www/jsonschema/object.schema.json"

--- a/features/json.feature
+++ b/features/json.feature
@@ -28,6 +28,8 @@ Feature: Testing JSONContext
         And the JSON node "numbers[3].complexeshizzle" should be equal to "true"
         And the JSON node "numbers[3].so[0]" should be equal to "very"
         And the JSON node "numbers[3].so[1].complicated" should be equal to "indeed"
+        And the JSON node "object[0]" should exist
+        And the JSON node "object[2]" should not exist
 
         And the JSON node "bar" should not exist
 

--- a/features/json.feature
+++ b/features/json.feature
@@ -72,6 +72,51 @@ Feature: Testing JSONContext
             }
             """
 
+
+    Scenario: Json validation deep
+        Given I am on "/json/booking.json"
+        Then the JSON should be invalid according to this schema:
+            """
+            {
+                "type":"object",
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "id": "http://jsonschema.net",
+                "required":false,
+                "properties":{
+                    "Booking": {
+                        "type":"object",
+                        "id": "http://jsonschema.net/Booking",
+                        "required":false
+                    },
+                    "Metadata": {
+                        "type":"object",
+                        "id": "http://jsonschema.net/Metadata",
+                        "required":false,
+                        "properties":{
+                            "First": {
+                                "type":"object",
+                                "id": "http://jsonschema.net/Metadata/First",
+                                "required":false,
+                                "properties":{
+                                    "default_value": {
+                                        "type":"boolean",
+                                        "id": "http://jsonschema.net/Metadata/First/default_value",
+                                        "required":false
+                                    },
+                                    "enabled": {
+                                        "type":"boolean",
+                                        "id": "http://jsonschema.net/Metadata/First/enabled",
+                                        "required":true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+
+
     Scenario: Json contents validation
         Given I am on "/json/imajson.json"
         Then the JSON should be equal to:

--- a/fixtures/www/json/booking.json
+++ b/fixtures/www/json/booking.json
@@ -1,0 +1,12 @@
+{
+    "Booking": {
+        "id": "1",
+        "price": "77.21"
+    }, "Metadata":
+    {
+        "First":  {
+            "bad_property_name": true,
+            "default_value": true
+        }
+    }
+}

--- a/fixtures/www/json/imajson.json
+++ b/fixtures/www/json/imajson.json
@@ -8,5 +8,11 @@
       "complexeshizzle": true,
       "so": ["very", {"complicated": "indeed"}]
     }
+  ],
+  "object": [{
+        "id": 1
+      }, {
+        "id":2
+      }
   ]
 }

--- a/fixtures/www/json/imajson.json
+++ b/fixtures/www/json/imajson.json
@@ -10,9 +10,11 @@
     }
   ],
   "object": [{
-        "id": 1
+        "id": 1,
+        "name": "mandatory"
       }, {
         "id":2
+
       }
   ]
 }

--- a/fixtures/www/jsonschema/object.schema.json
+++ b/fixtures/www/jsonschema/object.schema.json
@@ -1,0 +1,14 @@
+{
+    "type":"object",
+    "$schema": "http://json-schema.org/draft-03/schema",
+    "id": "http://jsonschema.net",
+    "required": ["id", "name"],
+    "properties":{
+        "id": {
+            "type":"number"
+        },
+        "name": {
+            "type":"string"
+        }
+    }
+}

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -128,12 +128,13 @@ class JsonContext extends BaseContext
         $json = $this->getJson();
 
         $e = null;
+        $actual = null;
         try {
             $actual = $this->getInspector()->evaluate($json, $node);
         } catch (\Exception $e) {
         }
 
-        if ($e === null) {
+        if (null === $e && null !== $actual) {
             throw new \Exception(sprintf("The node '%s' exists and contains '%s'.", $node , json_encode($actual)));
         }
     }

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -4,6 +4,7 @@ namespace Sanpi\Behatch\Context;
 
 use Behat\Gherkin\Node\PyStringNode;
 
+use Behat\Mink\Exception\ExpectationException;
 use Sanpi\Behatch\Json\Json;
 use Sanpi\Behatch\Json\JsonSchema;
 use Sanpi\Behatch\Json\JsonInspector;
@@ -146,6 +147,26 @@ class JsonContext extends BaseContext
             $this->getJson(),
             new JsonSchema($schema)
         );
+    }
+
+    /**
+     * @Then /^the JSON should be invalid according to this schema:$/
+     */
+    public function theJsonShouldBeInvalidAccordingToThisSchema(PyStringNode $schema)
+    {
+        try {
+            $isValid = $this->getInspector()->validate(
+                $this->getJson(),
+                new JsonSchema($schema)
+            );
+
+        } catch (\Exception $e) {
+            $isValid = false;
+        }
+
+        if (true === $isValid) {
+            throw new ExpectationException('Expected to receive invalid json, got valid one', $this->getSession());
+        }
     }
 
     /**

--- a/src/Json/Json.php
+++ b/src/Json/Json.php
@@ -13,6 +13,11 @@ class Json
         $this->content = $this->decode((string) $content);
     }
 
+    public function getContent()
+    {
+        return $this->content;
+    }
+
     public function read($expression, PropertyAccessor $accessor)
     {
         if (is_array($this->content)) {

--- a/src/Json/JsonSchema.php
+++ b/src/Json/JsonSchema.php
@@ -28,7 +28,7 @@ class JsonSchema extends Json
 
     public function validate(Json $json, Validator $validator)
     {
-        $validator->check($json, $this);
+        $validator->check($json->getContent(), $this->getContent());
 
         if (!$validator->isValid()) {
             $msg = "JSON does not validate. Violations:".PHP_EOL;

--- a/tests/units/Json/JsonSchema.php
+++ b/tests/units/Json/JsonSchema.php
@@ -60,7 +60,7 @@ class JsonSchema extends atoum
             )
                 ->mock($validator)
                     ->call('check')
-                    ->withArguments($json, $schema)
+                    ->withArguments($json->getContent(), $schema->getContent())
                     ->once()
 
                 ->boolean($result)


### PR DESCRIPTION
- Add @EmmanuelVella fix "Fix json schema validation" into branch behat-2.X
- Add step: in JsonContext:

  Then the JSON should be invalid according to this schema:
            xxxxxxxx
   the JSON node "(?P<node>[^"]*)" should be valid according to the schema "(?P<filename>[^"]*)"
   the JSON node "(?P<node>[^"]*)" should not be valid according to the schema "(?P<filename>[^"]*)"

- Fix step `the JSON node "Item[10]" should not exist` when the node is an array.
