### PR TITLE
Json node should have N elements on associative array

### DIFF
--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -69,7 +69,7 @@ class JsonContext extends BaseContext
 
         $actual = $this->getInspector()->evaluate($json, $node);
 
-        $this->assertSame((integer)$nth, sizeof($actual));
+        $this->assertSame((integer)$nth, sizeof((array) $actual));
     }
 
     /**


### PR DESCRIPTION
Json inspector evaluate associative array into `stdClass`, which always returns 1 on `sizeof()`.
So we need to cast it to `(array)` to know real count.
Test condition is not required because if node is scalar, method should return 1.