### PR TITLE
null and false values in JsonContext::theJsonNodeShouldBeEqualTo

### DIFF
--- a/features/json.feature
+++ b/features/json.feature
@@ -101,3 +101,9 @@ Feature: Testing JSONContext
         Then the response should be in JSON
         And the JSON node "root[0].name" should exist
         And the JSON node "root" should have 2 elements
+
+    Scenario: Check null and false values
+        Given I am on "/json/types.json"
+        Then the response should be in JSON
+        And the JSON node "foo" should be equal to "false"
+        And the JSON node "bar" should be equal to "null"

--- a/fixtures/www/json/types.json
+++ b/fixtures/www/json/types.json
@@ -1,0 +1,4 @@
+{
+    "foo": false,
+    "bar": null
+}

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -61,7 +61,7 @@ class JsonContext extends BaseContext
 
         $actual = $this->inspector->evaluate($json, $node);
 
-        if ($actual != $text) {
+        if ($actual != $text && !(false === $actual && 'false' === $text) && !(null === $actual && 'null' === $text)) {
             throw new \Exception(
                 sprintf("The node value is `%s`", json_encode($actual))
             );


### PR DESCRIPTION
Assuming this JSON document:
```json
{ "foo": false, "bar": null }
```

This PR allows to do the following:
```
Then the JSON node "foo" should be equal to "false"
And the JSON node "bar" should be equal to "null"
```