### PR TITLE
Fix the usage of `should not exist` with null values

### DIFF
--- a/features/json.feature
+++ b/features/json.feature
@@ -22,6 +22,8 @@ Feature: Testing JSONContext
         And the JSON node "foo" should contain "bar"
         And the JSON node "foo" should not contain "something else"
 
+        And the JSON node "foo2" should exist
+
         And the JSON node "numbers[0]" should contain "one"
         And the JSON node "numbers[1]" should contain "two"
         And the JSON node "numbers[2]" should contain "three"

--- a/fixtures/www/json/imajson.json
+++ b/fixtures/www/json/imajson.json
@@ -1,5 +1,6 @@
 {
   "foo": "bar",
+  "foo2": null,
   "numbers": [
     "one",
     "two",

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -128,13 +128,13 @@ class JsonContext extends BaseContext
         $json = $this->getJson();
 
         $e = null;
-        $actual = null;
+
         try {
             $actual = $this->getInspector()->evaluate($json, $node);
         } catch (\Exception $e) {
         }
 
-        if (null === $e && null !== $actual) {
+        if (null === $e) {
             throw new \Exception(sprintf("The node '%s' exists and contains '%s'.", $node , json_encode($actual)));
         }
     }

--- a/src/Json/JsonInspector.php
+++ b/src/Json/JsonInspector.php
@@ -16,7 +16,10 @@ class JsonInspector
     public function __construct($evaluationMode)
     {
         $this->evaluationMode = $evaluationMode;
-        $this->accessor = PropertyAccess::createPropertyAccessor();
+        $this->accessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->enableExceptionOnInvalidIndex()
+            ->getPropertyAccessor()
+        ;
     }
 
     public function evaluate(Json $json, $expression)


### PR DESCRIPTION
We have currently a big issue with the `should not exist` assertion

On this kind of payload
```json
{"error": {"property":null}}
```

the following step
```gherkin
And the JSON node "error.property" should not exist
```
is green.