### PR TITLE
Allow to use symfony framework's client

### DIFF
--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -192,7 +192,9 @@ class RestContext extends BaseContext
         $this->requestHeaders[$name] = $value;
 
         $client = $this->getSession()->getDriver()->getClient();
-        $client->setHeader($name, $value);
+        if (method_exists($client, 'setHeader')) {
+            $client->setHeader($name, $value);
+        }
     }
 
     /**


### PR DESCRIPTION
The Symfony framework's `Client` class don't have the `setHeader` method, but they can be passed while calling `request` as introduced by 06c075acc738b10984d970dc3a218df9113e1860.

This remove the fatal error of undefined method `getClient`.