### PR TITLE
Improve system context

### DIFF
--- a/i18n/fr.xliff
+++ b/i18n/fr.xliff
@@ -133,6 +133,14 @@
                 <source><![CDATA[command should last more than :seconds seconds]]></source>
                 <target><![CDATA[la commande devrait durer plus de :seconds secondes]]></target>
             </trans-unit>
+            <trans-unit id="i-should-see-on-output">
+                <source><![CDATA[(I )should see on output ":text"]]></source>
+                <target><![CDATA[(je )devrais voir sur la sortie ":text"]]></target>
+            </trans-unit>
+            <trans-unit id="i-should-not-see-on-output">
+                <source><![CDATA[(I )should not see on output ":text"]]></source>
+                <target><![CDATA[(je )ne devrais pas voir sur la sortie ":text"]]></target>
+            </trans-unit>
             <trans-unit id="i-create-the-file-contening">
                 <source><![CDATA[(I )create the file :filename containing:]]></source>
                 <target><![CDATA[(je )crée le fichier :filename contenant :]]></target>

--- a/i18n/fr.xliff
+++ b/i18n/fr.xliff
@@ -125,6 +125,14 @@
                 <source><![CDATA[(I )execute :command from project root]]></source>
                 <target><![CDATA[(j')exécute :command depuis la racine du projet]]></target>
             </trans-unit>
+            <trans-unit id="command-should-last-lett-than">
+                <source><![CDATA[command should last less than :seconds seconds]]></source>
+                <target><![CDATA[la commande devrait durer moins de :seconds secondes]]></target>
+            </trans-unit>
+            <trans-unit id="command-should-last-more-than">
+                <source><![CDATA[command should last more than :seconds seconds]]></source>
+                <target><![CDATA[la commande devrait durer plus de :seconds secondes]]></target>
+            </trans-unit>
             <trans-unit id="i-create-the-file-contening">
                 <source><![CDATA[(I )create the file :filename containing:]]></source>
                 <target><![CDATA[(je )crée le fichier :filename contenant :]]></target>

--- a/src/Context/SystemContext.php
+++ b/src/Context/SystemContext.php
@@ -9,6 +9,7 @@ use Behat\Gherkin\Node\PyStringNode;
 class SystemContext implements Context
 {
     private $root;
+    private $lastExecutionTime;
     private $createdFiles = [];
 
     public function __construct($root = '.')
@@ -42,7 +43,11 @@ class SystemContext implements Context
      */
     public function iExecute($cmd)
     {
+        $start = microtime(true);
+
         exec($cmd, $output, $return);
+
+        $this->lastExecutionTime = microtime(true) - $start;
 
         if ($return !== 0) {
             throw new \Exception(sprintf("Command %s returned with status code %s\n%s", $cmd, $return, implode("\n", $output)));
@@ -58,6 +63,30 @@ class SystemContext implements Context
     {
         $cmd = $this->root . DIRECTORY_SEPARATOR . $cmd;
         $this->iExecute($cmd);
+    }
+
+    /**
+     * Command should last less than
+     *
+     * @Then command should last less than :seconds seconds
+     */
+    public function commandShouldLastLessThan($seconds)
+    {
+        if ($this->lastExecutionTime > $seconds) {
+            throw new \Exception(sprintf("Last command last %s which is more than %s seconds", $lastExecutionTime, $seconds));
+        }
+    }
+
+    /**
+     * Command should last more than
+     *
+     * @Then command should last more than :seconds seconds
+     */
+    public function commandShouldMoreLessThan($seconds)
+    {
+        if ($this->lastExecutionTime < $seconds) {
+            throw new \Exception(sprintf("Last command last %s which is less than %s seconds", $lastExecutionTime, $seconds));
+        }
     }
 
     /**

--- a/src/Context/SystemContext.php
+++ b/src/Context/SystemContext.php
@@ -9,6 +9,7 @@ use Behat\Gherkin\Node\PyStringNode;
 class SystemContext implements Context
 {
     private $root;
+    private $output;
     private $lastExecutionTime;
     private $createdFiles = [];
 
@@ -45,12 +46,12 @@ class SystemContext implements Context
     {
         $start = microtime(true);
 
-        exec($cmd, $output, $return);
+        exec($cmd, $this->output, $return);
 
         $this->lastExecutionTime = microtime(true) - $start;
 
         if ($return !== 0) {
-            throw new \Exception(sprintf("Command %s returned with status code %s\n%s", $cmd, $return, implode("\n", $output)));
+            throw new \Exception(sprintf("Command %s returned with status code %s\n%s", $cmd, $return, implode("\n", $this->output)));
         }
     }
 
@@ -86,6 +87,44 @@ class SystemContext implements Context
     {
         if ($this->lastExecutionTime < $seconds) {
             throw new \Exception(sprintf("Last command last %s which is less than %s seconds", $lastExecutionTime, $seconds));
+        }
+    }
+
+    /**
+     * Checks, that output contains specified text.
+     *
+     * @Then (I )should see on output ":text"
+     */
+    public function iShouldSeeOnOutput($text)
+    {
+        $regex = '/'.preg_quote($text, '/').'/ui';
+
+        $check = false;
+        foreach ($this->output as $line) {
+            if (preg_match($regex, $line) === 1) {
+                $check = true;
+                break;
+            }
+        }
+
+        if ($check === false) {
+            throw new \Exception(sprintf("The text '%s' was not found anywhere on output of command.\n%s", $text, implode("\n", $this->output)));
+        }
+    }
+
+    /**
+     * Checks, that output not contains specified text.
+     *
+     * @Then (I )should not see on output ":text"
+     */
+    public function iShouldNotSeeOnOutput($text)
+    {
+        $regex = '/'.preg_quote($text, '/').'/ui';
+
+        foreach ($this->output as $line) {
+            if (preg_match($regex, $line) === 1) {
+                throw new \Exception(sprintf("The text '%s' was found somewhere on output of command.\n%s", $text, implode("\n", $this->output)));
+            }
         }
     }
 

--- a/tests/features/fr/system.feature
+++ b/tests/features/fr/system.feature
@@ -12,6 +12,11 @@ Fonctionnalité:
         Alors la commande devrait durer plus de 1 secondes
 
     Scénario:
+        Étant donné j'exécute "echo 'Hello world'"
+        Alors je devrais voir sur la sortie "Hello world"
+        Et je ne devrais pas voir sur la sortie "Hello John"
+
+    Scénario:
         Étant donné j'exécute "bin/behat --help"
 
     Scénario: création de fichier

--- a/tests/features/fr/system.feature
+++ b/tests/features/fr/system.feature
@@ -5,6 +5,13 @@ Fonctionnalité:
         Étant donné j'exécute "ls"
 
     Scénario:
+        Étant donné j'exécute "sleep 1"
+        Alors la commande devrait durer moins de 2 secondes
+
+        Étant donné j'exécute "sleep 2"
+        Alors la commande devrait durer plus de 1 secondes
+
+    Scénario:
         Étant donné j'exécute "bin/behat --help"
 
     Scénario: création de fichier

--- a/tests/features/system.feature
+++ b/tests/features/system.feature
@@ -10,6 +10,11 @@ Feature: System feature
         Given I execute "sleep 2"
         Then Command should last more than 1 seconds
 
+    Scenario: Testing execution output
+        Given I execute "echo 'Hello world'"
+        Then I should see on output "Hello world"
+        Then I should not see on output "Hello John"
+
     Scenario: Testing execution from the project root
         Given I execute "bin/behat --help"
 

--- a/tests/features/system.feature
+++ b/tests/features/system.feature
@@ -3,6 +3,13 @@ Feature: System feature
     Scenario: Testing execution
         Given I execute "ls"
 
+    Scenario: Testing execution time
+        Given I execute "sleep 1"
+        Then Command should last less than 2 seconds
+
+        Given I execute "sleep 2"
+        Then Command should last more than 1 seconds
+
     Scenario: Testing execution from the project root
         Given I execute "bin/behat --help"
 


### PR DESCRIPTION
Hi,

To test a command line tool, it would be nice to be able to check time of execution and the output, so I implemented 4 new steps in system context :

* `command should last less than :seconds seconds`
* `command should not last less than :seconds seconds`
* `(I )should see on output ":text"`
* `(I )should not see on output ":text"`

As I write this PR, I think about another step : `output should be :text`...