### PR TITLE
Fix "should be equal" for boolean values + Add "should not be equal to"

### DIFF
--- a/i18n/en.xliff.dist
+++ b/i18n/en.xliff.dist
@@ -147,6 +147,10 @@
                 <source>the JSON node :node should be equal to :text</source>
                 <target></target>
             </trans-unit>
+            <trans-unit id="the-json-node-should-not-be-equal-to">
+                <source>the JSON node :node should not be equal to :text</source>
+                <target></target>
+            </trans-unit>
             <trans-unit id="the-json-node-should-have-n-elements">
                 <source>the JSON node :node should have :count element(s)</source>
                 <target></target>

--- a/i18n/fr.xliff
+++ b/i18n/fr.xliff
@@ -147,6 +147,10 @@
                 <source><![CDATA[the JSON node :node should be equal to :text]]></source>
                 <target><![CDATA[/^le n(?:œ|oe)ud JSON "(?P<node>[^"]*)" devrait être égal à "(?P<text>[^"]*)"$/]]></target>
             </trans-unit>
+            <trans-unit id="the-json-node-should-not-be-equal-to">
+                <source><![CDATA[the JSON node :node should not be equal to :text]]></source>
+                <target><![CDATA[/^le n(?:œ|oe)ud JSON "(?P<node>[^"]*)" ne devrait pas être égal à "(?P<text>[^"]*)"$/]]></target>
+            </trans-unit>
             <trans-unit id="the-json-node-should-have-n-elements">
                 <source><![CDATA[the JSON node :node should have :count element(s)]]></source>
                 <target><![CDATA[/^le n(?:œ|oe)ud JSON "(?P<node>[^"]*)" devrait avoir (?P<count>\d+) éléments?$/]]></target>

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -56,6 +56,10 @@ class JsonContext extends BaseContext
 
         $actual = $this->inspector->evaluate($json, $node);
 
+        if (is_bool($actual)) {
+            $text = $text == 'true' ? true : false;
+        }
+
         if ($actual != $text) {
             throw new \Exception(
                 sprintf("The node value is '%s'", json_encode($actual))
@@ -72,6 +76,28 @@ class JsonContext extends BaseContext
     {
         foreach ($nodes->getRowsHash() as $node => $text) {
             $this->theJsonNodeShouldBeEqualTo($node, $text);
+        }
+    }
+
+    /**
+     * Checks, that given JSON node is not equal to given value
+     *
+     * @Then the JSON node :node should not be equal to :text
+     */
+    public function theJsonNodeShouldNotBeEqualTo($node, $text)
+    {
+        $json = $this->getJson();
+
+        $actual = $this->inspector->evaluate($json, $node);
+
+        if (is_bool($actual)) {
+            $text = $text == 'true' ? true : false;
+        }
+
+        if ($actual == $text) {
+            throw new \Exception(
+                sprintf("The node value is '%s'", json_encode($actual))
+            );
         }
     }
 

--- a/tests/features/json.feature
+++ b/tests/features/json.feature
@@ -26,8 +26,13 @@ Feature: Testing JSONContext
         And the JSON node "numbers[1]" should contain "two"
         And the JSON node "numbers[2]" should contain "three"
         And the JSON node "numbers[3].complexeshizzle" should be equal to "true"
+        And the JSON node "numbers[3].invertedcomplexeshizzle" should be equal to "false"
+        And the JSON node "numbers[3].complexeshizzle" should not be equal to "false"
+        And the JSON node "numbers[3].invertedcomplexeshizzle" should not be equal to "true"
         And the JSON node "numbers[3].so[0]" should be equal to "very"
+        And the JSON node "numbers[3].so[0]" should not be equal to "very much"
         And the JSON node "numbers[3].so[1].complicated" should be equal to "indeed"
+        And the JSON node "numbers[3].so[1].complicated" should not be equal to "not indeed"
 
         And the JSON nodes should be equal to:
             | foo        | bar   |
@@ -99,6 +104,7 @@ Feature: Testing JSONContext
                     "three",
                     {
                         "complexeshizzle": true,
+                        "invertedcomplexeshizzle": false,
                         "so": [
                             "very",
                             {

--- a/tests/fixtures/www/json/imajson.json
+++ b/tests/fixtures/www/json/imajson.json
@@ -6,6 +6,7 @@
     "three",
     {
       "complexeshizzle": true,
+      "invertedcomplexeshizzle": false,
       "so": ["very", {"complicated": "indeed"}]
     }
   ]


### PR DESCRIPTION
There was an error with the "should be equal to" when the actual value is a boolean:
I added a test and fixed it.

I added a "should **not** be equal to" assertion.

Thank you !