### PR TITLE
Fix typos in the doc

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,19 +2,19 @@ Behatch contexts
 ================
 
 .. image:: https://travis-ci.org/Behatch/contexts.svg?branch=master
-:target: https://travis-ci.org/Behatch/contexts
+    :target: https://travis-ci.org/Behatch/contexts
     :alt: Build status
 
 .. image:: https://scrutinizer-ci.com/g/Behatch/contexts/badges/quality-score.png?b=master
-:target: https://scrutinizer-ci.com/g/Behatch/contexts/?branch=master
+    :target: https://scrutinizer-ci.com/g/Behatch/contexts/?branch=master
     :alt: Scrutinizer Code Quality
 
 .. image:: https://scrutinizer-ci.com/g/Behatch/contexts/badges/coverage.png?b=code-coverage
-:target: https://scrutinizer-ci.com/g/Behatch/contexts/?branch=code-coverage
+    :target: https://scrutinizer-ci.com/g/Behatch/contexts/?branch=code-coverage
     :alt: Code Coverage
 
 .. image:: https://insight.sensiolabs.com/projects/ed08ea06-93c2-4b90-b65b-4364302b5108/mini.png
-:target: https://insight.sensiolabs.com/projects/ed08ea06-93c2-4b90-b65b-4364302b5108
+    :target: https://insight.sensiolabs.com/projects/ed08ea06-93c2-4b90-b65b-4364302b5108
     :alt: SensioLabsInsight
 
     Behatch contexts provide most common Behat tests.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,7 +17,7 @@ Behatch contexts
     :target: https://insight.sensiolabs.com/projects/ed08ea06-93c2-4b90-b65b-4364302b5108
     :alt: SensioLabsInsight
 
-    Behatch contexts provide most common Behat tests.
+Behatch contexts provide most common Behat tests.
 
 Installation
 ------------
@@ -142,5 +142,5 @@ Translation
 -----------
 
 .. image:: https://www.transifex.com/projects/p/behatch-contexts/resource/enxliff/chart/image_png
-:target: https://www.transifex.com/projects/p/behatch-contexts/
+    :target: https://www.transifex.com/projects/p/behatch-contexts/
     :alt: See more information on Transifex.com

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,22 +2,22 @@ Behatch contexts
 ================
 
 .. image:: https://travis-ci.org/Behatch/contexts.svg?branch=master
-    :target: https://travis-ci.org/Behatch/contexts
+:target: https://travis-ci.org/Behatch/contexts
     :alt: Build status
 
 .. image:: https://scrutinizer-ci.com/g/Behatch/contexts/badges/quality-score.png?b=master
-    :target: https://scrutinizer-ci.com/g/Behatch/contexts/?branch=master
+:target: https://scrutinizer-ci.com/g/Behatch/contexts/?branch=master
     :alt: Scrutinizer Code Quality
 
 .. image:: https://scrutinizer-ci.com/g/Behatch/contexts/badges/coverage.png?b=code-coverage
-    :target: https://scrutinizer-ci.com/g/Behatch/contexts/?branch=code-coverage
+:target: https://scrutinizer-ci.com/g/Behatch/contexts/?branch=code-coverage
     :alt: Code Coverage
 
 .. image:: https://insight.sensiolabs.com/projects/ed08ea06-93c2-4b90-b65b-4364302b5108/mini.png
-    :target: https://insight.sensiolabs.com/projects/ed08ea06-93c2-4b90-b65b-4364302b5108
+:target: https://insight.sensiolabs.com/projects/ed08ea06-93c2-4b90-b65b-4364302b5108
     :alt: SensioLabsInsight
 
-Behatch contexts provide most common behat tests.
+    Behatch contexts provide most common Behat tests.
 
 Installation
 ------------
@@ -54,10 +54,10 @@ Through Composer
 The easiest way to keep your suite updated is to use
 `Composer <http://getcomposer.org>`_.
 
-You can add behatch contexts as dependancies for your project or rapidly
-bootstrap a behatch projects.
+You can add Behatch contexts as dependencies for your project or rapidly
+bootstrap a Behatch projects.
 
-Project dependancy
+Project dependency
 ******************
 
 1. Define dependencies in your ``composer.json``:
@@ -92,7 +92,7 @@ Project dependancy
 Project boostraping
 *******************
 
-1. Download the behatch skeleton with composer:
+1. Download the Behatch skeleton with composer:
 
 .. code-block:: bash
 
@@ -102,7 +102,7 @@ Project boostraping
 .. note::
 
     Browser, json, table and rest step need a mink configuration, see
-    `Mink extension <http://extensions.behat.org/mink/>`_ for more informations.
+    `Mink extension <http://extensions.behat.org/mink/>`_ for more information.
 
 Usage
 -----
@@ -128,7 +128,7 @@ Configuration
 
 * ``browser`` - more browser related steps (like mink)
     * ``timeout`` - default timeout
-* ``debug`` - helper steps for debuging
+* ``debug`` - helper steps for debugging
     * ``screenshotDir`` - the directory where store screenshots
 * ``system`` - shell related steps
     * ``root`` - the root directory of the filesystem
@@ -142,5 +142,5 @@ Translation
 -----------
 
 .. image:: https://www.transifex.com/projects/p/behatch-contexts/resource/enxliff/chart/image_png
-    :target: https://www.transifex.com/projects/p/behatch-contexts/
+:target: https://www.transifex.com/projects/p/behatch-contexts/
     :alt: See more information on Transifex.com


### PR DESCRIPTION
Fix some typos and make the writing of Behat and Behatch more consistent in doc\index.rst