### PR TITLE
Allow to extend JsonContext

### DIFF
--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -12,9 +12,9 @@ use Sanpi\Behatch\HttpCall\HttpCallResultPool;
 
 class JsonContext extends BaseContext
 {
-    private $inspector;
+    protected $inspector;
 
-    private $httpCallResultPool;
+    protected $httpCallResultPool;
 
     public function __construct(HttpCallResultPool $httpCallResultPool, $evaluationMode = 'javascript')
     {
@@ -232,7 +232,7 @@ class JsonContext extends BaseContext
             ->encode();
     }
 
-    private function getJson()
+    protected function getJson()
     {
         return new Json($this->httpCallResultPool->getResult()->getValue());
     }


### PR DESCRIPTION
This PR allow to extend JsonContext and use `getJson()` method.
It also allow to use `inspector` and `httpCallResultPool` properties too.

Now we'll be able to create custom methods which need the method or the properties.

What do you think of this PR ?