### PR TITLE
Add "command should (succeed|fail)"

### DIFF
--- a/i18n/en.xliff.dist
+++ b/i18n/en.xliff.dist
@@ -125,6 +125,14 @@
                 <source>(I )execute :command from project root</source>
                 <target></target>
             </trans-unit>
+            <trans-unit id="command-should-succeed">
+                <source>command should succeed</source>
+                <target></target>
+            </trans-unit>
+            <trans-unit id="command-should-fail">
+                <source>command should fail</source>
+                <target></target>
+            </trans-unit>
             <trans-unit id="command-should-last-lett-than">
                 <source>command should last less than :seconds seconds</source>
                 <target></target>

--- a/i18n/fr.xliff
+++ b/i18n/fr.xliff
@@ -125,6 +125,14 @@
                 <source><![CDATA[(I )execute :command from project root]]></source>
                 <target><![CDATA[(j')exécute :command depuis la racine du projet]]></target>
             </trans-unit>
+            <trans-unit id="command-should-succeed">
+                <source><![CDATA[command should succeed]]></source>
+                <target><![CDATA[la commande devrait réussir]]></target>
+            </trans-unit>
+            <trans-unit id="command-should-fail">
+                <source><![CDATA[command should fail]]></source>
+                <target><![CDATA[la commande planter]]></target>
+            </trans-unit>
             <trans-unit id="command-should-last-lett-than">
                 <source><![CDATA[command should last less than :seconds seconds]]></source>
                 <target><![CDATA[la commande devrait durer moins de :seconds secondes]]></target>

--- a/src/Context/SystemContext.php
+++ b/src/Context/SystemContext.php
@@ -11,6 +11,7 @@ class SystemContext implements Context
     private $root;
     private $output;
     private $lastExecutionTime;
+    private $lastReturnCode;
     private $createdFiles = [];
 
     public function __construct($root = '.')
@@ -46,13 +47,9 @@ class SystemContext implements Context
     {
         $start = microtime(true);
 
-        exec($cmd, $this->output, $return);
+        exec($cmd, $this->output, $this->lastReturnCode);
 
         $this->lastExecutionTime = microtime(true) - $start;
-
-        if ($return !== 0) {
-            throw new \Exception(sprintf("Command %s returned with status code %s\n%s", $cmd, $return, implode("\n", $this->output)));
-        }
     }
 
     /**
@@ -64,6 +61,28 @@ class SystemContext implements Context
     {
         $cmd = $this->root . DIRECTORY_SEPARATOR . $cmd;
         $this->iExecute($cmd);
+    }
+
+    /**
+     * Command should succeed
+     *
+     * @Then command should succeed
+     */
+    public function commandShouldSucceed() {
+        if ($this->lastReturnCode !== 0) {
+            throw new \Exception(sprintf("Command should succeed %b", $this->lastReturnCode));
+        };
+    }
+
+    /**
+     * Command should fail
+     *
+     * @Then command should fail
+     */
+    public function commandShouldFail() {
+        if ($this->lastReturnCode === 0) {
+            throw new \Exception(sprintf("Command should fail %b", $this->lastReturnCode));
+        };
     }
 
     /**

--- a/tests/features/fr/system.feature
+++ b/tests/features/fr/system.feature
@@ -2,7 +2,10 @@
 Fonctionnalité:
 
     Scénario:
-        Étant donné j'exécute "ls"
+        Étant donné j'exécute "true"
+        Alors la commande devrait réussir
+        Étant donné j'exécute "false"
+        Alors la commande planter
 
     Scénario:
         Étant donné j'exécute "sleep 1"

--- a/tests/features/system.feature
+++ b/tests/features/system.feature
@@ -1,7 +1,10 @@
 Feature: System feature
 
     Scenario: Testing execution
-        Given I execute "ls"
+        Given I execute "true"
+        Then command should succeed
+        Given I execute "false"
+        Then command should fail
 
     Scenario: Testing execution time
         Given I execute "sleep 1"


### PR DESCRIPTION
I would not raise an exception on "I execute" action if the command fail but stored return code to be able to test it with "command should succeed" and "command should fail" actions.

What do you think?