### PR TITLE
Fix $ref resolution problems

### DIFF
--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -187,11 +187,7 @@ class JsonContext extends BaseContext
      */
     public function theJsonShouldBeValidAccordingToTheSchema($filename)
     {
-        if (false === is_file($filename)) {
-            throw new \RuntimeException(
-                'The JSON schema doesn\'t exist'
-            );
-        }
+        $this->checkSchemaFile($filename);
 
         $this->inspector->validate(
             $this->getJson(),
@@ -200,6 +196,18 @@ class JsonContext extends BaseContext
                 'file://' . getcwd() . '/' . $filename
             )
         );
+    }
+
+    /**
+     * @Then the JSON should be invalid according to the schema :filename
+     */
+    public function theJsonShouldBeInvalidAccordingToTheSchema($filename)
+    {
+        $this->checkSchemaFile($filename);
+
+        $this->not(function () use($filename) {
+            return $this->theJsonShouldBeValidAccordingToTheSchema($filename);
+        }, "The schema was valid");
     }
 
     /**
@@ -235,5 +243,14 @@ class JsonContext extends BaseContext
     private function getJson()
     {
         return new Json($this->httpCallResultPool->getResult()->getValue());
+    }
+
+    private function checkSchemaFile($filename)
+    {
+        if (false === is_file($filename)) {
+            throw new \RuntimeException(
+                'The JSON schema doesn\'t exist'
+            );
+        }
     }
 }

--- a/src/Json/JsonSchema.php
+++ b/src/Json/JsonSchema.php
@@ -21,7 +21,7 @@ class JsonSchema extends Json
             return $this;
         }
 
-        $resolver->resolve($this->encode(false), $this->uri);
+        $resolver->resolve($this->getContent(), $this->uri);
 
         return $this;
     }

--- a/tests/features/json.feature
+++ b/tests/features/json.feature
@@ -50,6 +50,10 @@ Feature: Testing JSONContext
         Given I am on "/json/imajson.json"
         Then the JSON should be valid according to the schema "tests/fixtures/www/json/schema.json"
 
+    Scenario: Json validation with schema containing ref (invalid case)
+        Given I am on "/json/withref-invalid.json"
+        Then the JSON should be invalid according to the schema "tests/fixtures/www/json/schemaref.json"
+
     Scenario: Json validation with schema containing ref
         Given I am on "/json/withref.json"
         Then the JSON should be valid according to the schema "tests/fixtures/www/json/schemaref.json"

--- a/tests/fixtures/www/json/withref-invalid.json
+++ b/tests/fixtures/www/json/withref-invalid.json
@@ -1,0 +1,4 @@
+{
+    "foo": "not a uri",
+    "bar": "not a uri"
+}

--- a/tests/units/Json/JsonSchema.php
+++ b/tests/units/Json/JsonSchema.php
@@ -35,7 +35,7 @@ class JsonSchema extends \atoum
             )
                 ->mock($resolver)
                     ->call('resolve')
-                    ->withArguments('{}', 'file://test')
+                    ->withArguments(json_decode('{}'), 'file://test')
                     ->once()
 
                 ->object($result)


### PR DESCRIPTION
Following issue #95 

In order for the $refs to be resolved correctly within the JSONSchema library, we need to pass a reference to the original JSON object, rather than a copy of its content, when resolving.  This is because the library alters the object when it does its dereferencing.