### PR TITLE
Fix RequestHeaders

### DIFF
--- a/src/HttpCall/Request.php
+++ b/src/HttpCall/Request.php
@@ -3,28 +3,53 @@
 namespace Sanpi\Behatch\HttpCall;
 
 use Behat\Mink\Mink;
+use Sanpi\Behatch\HttpCall\Request\BrowserKit;
+use Sanpi\Behatch\HttpCall\Request\Goutte;
 
 class Request
 {
+    /**
+     * @var Mink
+     */
     private $mink;
 
+    /**
+     * @var Goutte|BrowserKit
+     */
+    private $client;
+
+    /**
+     * @param Mink $mink
+     */
     public function __construct(Mink $mink)
     {
         $this->mink = $mink;
     }
 
+    /**
+     * @param string $name
+     * @param array $arguments
+     *
+     * @return mixed
+     */
     public function __call($name, $arguments)
     {
         return call_user_func_array([$this->getClient(), $name], $arguments);
     }
 
+    /**
+     * @return BrowserKit|Goutte
+     */
     private function getClient()
     {
-        if ($this->mink->getDefaultSessionName() === 'symfony2') {
-            return new Request\Goutte($this->mink);
+        if (is_null($this->client)) {
+            if ($this->mink->getDefaultSessionName() === 'symfony2') {
+                $this->client = new Goutte($this->mink);
+            } else {
+                $this->client = new BrowserKit($this->mink);
+            }
         }
-        else {
-            return new Request\BrowserKit($this->mink);
-        }
+
+        return $this->client;
     }
 }


### PR DESCRIPTION
Hey,

This PR fixes setting Headers before sending a request in the request-class.
Actually the Client got instantiated on each Methodcall of a Requestinstance which resulted in setting headers before a request had no effect.

e.g.

```
$request->setHttpHeader(xxx, yyy); // invokes __call in request which first instaniates a new client
$request->send(xxx); // here you've got a fresh instance of the client, too
```
