### PR TITLE
Add missing return statement in iSendARequestToWithBody

### DIFF
--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -71,7 +71,7 @@ class RestContext extends BaseContext
      */
     public function iSendARequestToWithBody($method, $url, PyStringNode $body)
     {
-        $this->iSendARequestTo($method, $url, $body);
+        return $this->iSendARequestTo($method, $url, $body);
     }
 
     /**


### PR DESCRIPTION
I find this return important. Without it I cannot access the response.