### PR TITLE
Make tests run faster

### DIFF
--- a/src/Context/BrowserContext.php
+++ b/src/Context/BrowserContext.php
@@ -161,6 +161,24 @@ class BrowserContext extends BaseContext
     }
 
     /**
+     * Checks, that the page should not contain specified text before given timeout
+     *
+     * @Then (I )should not see :text within :count second(s)
+     */
+    public function iDontSeeInSeconds($count, $text)
+    {
+        $caught = false;
+        try {
+            $this->iWaitSecondsUntilISee($count, $text);
+        }
+        catch (ExpectationException $e) {
+            $caught = true;
+        }
+
+        $this->assertTrue($caught, "Text '$text' has been found");
+    }
+
+    /**
      * Checks, that the page should contains specified text after timeout
      *
      * @Then (I )wait until I see :text
@@ -198,6 +216,10 @@ class BrowserContext extends BaseContext
                 // assume page reloaded whilst we were still waiting
             }
         } while (!$found && (time() - $startTime < $count));
+
+        // final assertion...
+        $node = $this->getSession()->getPage()->find('css', $element);
+        $this->assertContains($expected, $node->getText(), $message);
     }
 
     /**

--- a/tests/features/browser.feature
+++ b/tests/features/browser.feature
@@ -62,10 +62,11 @@ Feature: Browser Feature
     @javascript
     Scenario: Wait before seeing
         Given I am on "/browser/timeout.html"
-        Then I wait 3 seconds until I see "timeout"
+        When I wait 3 seconds until I see "timeout"
         And I wait 1 second
         And I wait for "#iframe" element
         And I wait 5 seconds for "#iframe" element
+        Then the total elapsed time should be less than 6 seconds
 
     @javascript
     Scenario: Check element visibility
@@ -83,3 +84,10 @@ Feature: Browser Feature
     Scenario:
         Given I am on "/browser/elements.html"
         Then i save the value of "today" in the "today" parameter
+
+    Scenario: Waiting for fractions of a second
+        Given I am on "/browser/index.html"
+        And I wait 1.9 seconds
+        And I wait 1.9 seconds
+        And I wait 1.9 seconds
+        Then the total elapsed time should be more than 4 seconds

--- a/tests/features/browser.feature
+++ b/tests/features/browser.feature
@@ -69,6 +69,17 @@ Feature: Browser Feature
         Then the total elapsed time should be less than 6 seconds
 
     @javascript
+    Scenario: Waited upon text should actually be visible
+        Given I am on "/browser/timeout.html"
+        Then I should not see "timeout"
+        When I wait 3 seconds until I see "timeout"
+        Then I should see "timeout"
+
+    Scenario: Waited upon text should actually be visible
+        Given I am on "/browser/index.html"
+        Then I should not see "foobar" within 1 second
+
+    @javascript
     Scenario: Check element visibility
         Given I am on "/browser/index.html"
         Then the "#visible-element" element should be visible


### PR DESCRIPTION
_was Only wait until element appears & fractional waits_

Introduces two new features:
- **limited-waiting**  
  when waiting until an element or text appears, this limits the wait until the condition is satisfied. Currently, the wait is for the time specified regardless of whether or not the condition becomes true, causing tests to take much longer than they need to:  
  _Example:_ `When I wait 3 seconds until I see "timeout"` currently always waits 3 seconds, even if "timeout" appears after 0.1 seconds. Also the wait previously was a hard loop. I have introduced a 1 millisecond wait to ease this.
- **fractional-waiting**  
  allows the time specified by "wait for" steps to be fractional  
  _Example:_ `When I wait   for 0.1 second`. Again, this can speed test suites when you need to wait but not for a whole second.

I have committed both features together as the elapsedTime() code behind the test scenarios is common to both.
