### PR TITLE
Simplify Composer installation instructions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -78,8 +78,8 @@ Project dependency
         extensions:
             Sanpi\Behatch\Extension: ~
 
-Project boostraping
-*******************
+Project bootstraping
+********************
 
 1. Download the Behatch skeleton with composer:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,24 +60,13 @@ bootstrap a Behatch projects.
 Project dependency
 ******************
 
-1. Define dependencies in your ``composer.json``:
+1. `Install Composer <https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx>`_
 
-.. code-block:: js
-
-    {
-        "require-dev": {
-            ...
-
-            "behatch/contexts": "*"
-        }
-    }
-
-2. Install/update your vendors:
+2. Require the package with Composer:
 
 .. code-block:: bash
 
-    $ curl http://getcomposer.org/installer | php
-    $ php composer.phar install
+    $ composer require --dev behatch/contexts
 
 3. Activate extension by specifying its class in your ``behat.yml``:
 
@@ -96,7 +85,6 @@ Project boostraping
 
 .. code-block:: bash
 
-    $ curl http://getcomposer.org/installer | php
     $ php composer.phar create-project behatch/skeleton
 
 .. note::


### PR DESCRIPTION
Typing a command is simpler than editing a file: you get
auto-completion, there are less keys to press, you do not need to open
an editor… besides, `"*"` is not a really good versioning constraints,
because it does not protect the user from BC-breaks. Not specifying a
version constraint in the command will result in Composer applying whatever
the current best-practice is.
This also removes outdated instructions for installing Composer, linking
to the dedicated page instead, because we probably do not want to
maintain this.
