### PR TITLE
Do not transform not string files before send to client

### DIFF
--- a/src/HttpCall/Request/BrowserKit.php
+++ b/src/HttpCall/Request/BrowserKit.php
@@ -58,7 +58,9 @@ class BrowserKit
     public function send($method, $url, $parameters = [], $files = [], $content = null, $headers = [])
     {
         foreach ($files as $originalName => &$file) {
-            $file = new UploadedFile($file, $originalName);
+            if (is_string($file)) {
+                $file = new UploadedFile($file, $originalName);
+            }
         }
 
         $client = $this->mink->getSession()->getDriver()->getClient();
@@ -109,12 +111,10 @@ class BrowserKit
         if (isset($headers[$name])) {
             if (is_array($headers[$name])) {
                 $value = implode(', ', $headers[$name]);
-            }
-            else {
+            } else {
                 $value = $headers[$name];
             }
-        }
-        else {
+        } else {
             throw new \OutOfBoundsException(
                 "The header '$name' doesn't exist"
             );

--- a/src/HttpCall/Request/Goutte.php
+++ b/src/HttpCall/Request/Goutte.php
@@ -2,8 +2,6 @@
 
 namespace Sanpi\Behatch\HttpCall\Request;
 
-use Symfony\Component\HttpFoundation\File\UploadedFile;
-
 class Goutte extends BrowserKit
 {
     /**

--- a/src/HttpCall/Request/Goutte.php
+++ b/src/HttpCall/Request/Goutte.php
@@ -17,7 +17,9 @@ class Goutte extends BrowserKit
     public function send($method, $url, $parameters = [], $files = [], $content = null, $headers = [])
     {
         foreach ($files as $originalName => &$file) {
-            $file = new UploadedFile($file, $originalName);
+            if (is_string($file)) {
+                $file = new UploadedFile($file, $originalName);
+            }
         }
         $page = parent::send($method, $url, $parameters, $files, $content, $this->requestHeaders);
         $this->resetHttpHeaders();

--- a/src/HttpCall/Request/Goutte.php
+++ b/src/HttpCall/Request/Goutte.php
@@ -16,11 +16,6 @@ class Goutte extends BrowserKit
 
     public function send($method, $url, $parameters = [], $files = [], $content = null, $headers = [])
     {
-        foreach ($files as $originalName => &$file) {
-            if (is_string($file)) {
-                $file = new UploadedFile($file, $originalName);
-            }
-        }
         $page = parent::send($method, $url, $parameters, $files, $content, $this->requestHeaders);
         $this->resetHttpHeaders();
 


### PR DESCRIPTION
Before sending a request using mink driver client, browserKit converts all items in files[] to uploadedFile instances; with this PR you can now pass directly custom uploadedFiles