### PR TITLE
added a few accesibility checks.    more to come.

### DIFF
--- a/src/Context/AccesibilityContext.php
+++ b/src/Context/AccesibilityContext.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Sanpi\Behatch\Context;
+
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ExpectationException;
+use Behat\Mink\Exception\ResponseTextException;
+use Behat\Mink\Exception\ElementNotFoundException;
+
+class AccesibilityContext extends BaseContext
+{
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @Then all images should have an alt attribute
+     */
+    public function allImagesShouldHaveAnAltAttribute()
+    {
+        $images = $this->getSession()->getPage()->findAll('xpath', '//img[not(@alt)]');
+        if ($images != null) {
+            throw new \Exception("There are images without an alt attribute");
+        } 
+    }
+
+    /**
+     * @Then the title should not be longer than :arg1
+     */
+    public function theTitleShouldNotBeLongerThan($arg1)
+    {
+        $title = $this->getSession()->getPage()->find('css', 'h1')->getText();
+        if (strlen($title) > $arg1) {
+            throw new \Exception("The h1 title is more than '$arg1' characters long");
+        }
+    }
+
+    /**
+     * @Then all tables should have a table header
+     */
+    public function allTablesShouldHaveATableHeader()
+    {
+        $tables = $this->getSession()->getPage()->findAll('xpath', '//table/*[not(th)]');
+        if ($tables != null) {
+            throw new \Exception("There are tables without a table header");
+        }
+    }
+}


### PR DESCRIPTION
Extending the BaseContext for some accesibility checks.

Plan to add these as well:

* Headings:   
** each page should have one and only one H1 element.
** the H1 element should not be longer than 70 chars in length.
** each page should have at least one H2 element
* Images
** Each image should have an alt attribute, possibly empty.
** If a title attribute is present, it should differ in value from the alt attribute
* Tables
* Each table should have a heading and at least one data row
* Anchors
** for each a:hover there should also be an a:focus 
** title attribute should differ in value from the text in between the a tags
* Forms
** each formfield should have a label
** all labels should have a for attribute, linked to the formfield
* Page
** check for skip navigation
** check doctype present
** check lang attribute