### PR TITLE
Fix http headers

### DIFF
--- a/src/HttpCall/Request.php
+++ b/src/HttpCall/Request.php
@@ -10,7 +10,12 @@ class Request
      * @var Mink
      */
     private $mink;
-
+    
+    /**
+     * @var Request\Goutte|Request\BrowserKit
+     */
+    private $client;
+    
     /**
      * Request constructor.
      * @param Mink $mink
@@ -35,11 +40,14 @@ class Request
      */
     private function getClient()
     {
-        if ($this->mink->getDefaultSessionName() === 'symfony2') {
-            return new Request\Goutte($this->mink);
+        if (!$this->client) {
+            if ($this->mink->getDefaultSessionName() === 'symfony2') {
+                $this->client = new Request\Goutte($this->mink);
+            }
+            else {
+                $this->client = Request\BrowserKit($this->mink);
+            }
         }
-        else {
-            return new Request\BrowserKit($this->mink);
-        }
+        return $this->client;
     }
 }

--- a/src/HttpCall/Request.php
+++ b/src/HttpCall/Request.php
@@ -10,12 +10,7 @@ class Request
      * @var Mink
      */
     private $mink;
-    
-    /**
-     * @var Request\Goutte|Request\BrowserKit
-     */
-    private $client;
-    
+
     /**
      * Request constructor.
      * @param Mink $mink
@@ -40,14 +35,11 @@ class Request
      */
     private function getClient()
     {
-        if (!$this->client) {
-            if ($this->mink->getDefaultSessionName() === 'symfony2') {
-                $this->client = new Request\Goutte($this->mink);
-            }
-            else {
-                $this->client = Request\BrowserKit($this->mink);
-            }
+        if ($this->mink->getDefaultSessionName() === 'symfony2') {
+            return new Request\Goutte($this->mink);
         }
-        return $this->client;
+        else {
+            return new Request\BrowserKit($this->mink);
+        }
     }
 }

--- a/src/HttpCall/Request/Goutte.php
+++ b/src/HttpCall/Request/Goutte.php
@@ -34,7 +34,14 @@ class Goutte extends BrowserKit
 
     public function setHttpHeader($name, $value)
     {
-        $name = strtoupper("http_$name");
+        $contentHeaders = ['CONTENT_LENGTH' => true, 'CONTENT_MD5' => true, 'CONTENT_TYPE' => true];
+        $name = str_replace('-', '_', strtoupper($name));
+
+        // CONTENT_* are not prefixed with HTTP_ in PHP when building $_SERVER
+        if (!isset($contentHeaders[$name])) {
+            $name = 'HTTP_' . $name;
+        }
+        
         $this->requestHeaders[$name] = $value;
     }
 


### PR DESCRIPTION
Two things: 1) it stores the client so headers are lost between calls to setHttpHeaders. 2) setHttpHeaders handles Content headers appropriately.