### PR TITLE
Fix JSON schema validation via :filename for absolute paths

### DIFF
--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -332,6 +332,8 @@ class JsonContext extends BaseContext
      */
     public function theJsonShouldBeInvalidAccordingToTheSchema($filename)
     {
+        $this->checkSchemaFile($filename);
+
         $this->not(function () use($filename) {
             return $this->theJsonShouldBeValidAccordingToTheSchema($filename);
         }, "The schema was valid");

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -322,7 +322,7 @@ class JsonContext extends BaseContext
             $this->getJson(),
             new JsonSchema(
                 file_get_contents($filename),
-                'file://' . getcwd() . '/' . $filename
+                'file://' . realpath($filename)
             )
         );
     }
@@ -332,8 +332,6 @@ class JsonContext extends BaseContext
      */
     public function theJsonShouldBeInvalidAccordingToTheSchema($filename)
     {
-        $this->checkSchemaFile($filename);
-
         $this->not(function () use($filename) {
             return $this->theJsonShouldBeValidAccordingToTheSchema($filename);
         }, "The schema was valid");

--- a/src/Json/JsonInspector.php
+++ b/src/Json/JsonInspector.php
@@ -37,16 +37,6 @@ class JsonInspector
         $resolver = new \JsonSchema\SchemaStorage(new \JsonSchema\Uri\UriRetriever, new \JsonSchema\Uri\UriResolver);
         $schema->resolve($resolver);
 
-        $validator->check($json->getContent(), $schema->getContent());
-        $isValid = $validator->isValid();
-        if (!$isValid) {
-            $msg = "JSON does not validate. Violations:".PHP_EOL;
-            foreach ($validator->getErrors() as $error) {
-                $msg .= sprintf("  - [%s] %s".PHP_EOL, $error['property'], $error['message']);
-            }
-            throw new \Exception($msg);
-        }
-
-        return $isValid;
+        return $schema->validate($json, $validator);
     }
 }


### PR DESCRIPTION
The step `Then the JSON should be valid according to the schema :filename` currently does not work with absolute paths, because of the use of `getcwd()` inside.

I fixed this by using `realpath($filename)` instead.
Unfortunately, I didn't know how to add a suitable testcase for this.

It would be something like this (tested on my machine with a real path):
```
    Scenario: Json validation with schema (absolute path)
        Given I am on "/json/imajson.json"
        Then the JSON should be valid according to the schema "/path/to/behatch/contexts/tests/fixtures/www/json/schema.json"
```
This would fail with the old code(`'file://' . getcwd() . '/' . $filename`), but work with the new code (`'file://' . realpath($filename)`).
But obviously I can't just add an absolute path in the testsuite, because I don't know where it is run. If you have any idea, how to add a suitable testcase for this, feel free to suggest or add it yourself.


Also did a small refactoring to remove duplicate code in JsonInspector.php.