### PR TITLE
Fix set content headers

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -23,8 +23,6 @@ default:
             selenium2: ~
             browser_name: 'chrome'
             sessions:
-                default:
-                    goutte: ~
                 symfony2:
                     goutte: ~
         Behatch\Extension: ~

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -16,18 +16,20 @@ default:
                 - behatch:context:table
                 - behatch:context:xml
     extensions:
-        Behat\MinkExtension\ServiceContainer\MinkExtension:
+        Behat\MinkExtension:
             base_url: 'http://localhost:8080'
             files_path: 'tests/fixtures/files'
             goutte: ~
             selenium2: ~
             browser_name: 'chrome'
             sessions:
+                default:
+                    goutte: ~
                 symfony2:
                     goutte: ~
         Behatch\Extension: ~
 
 symfony2:
     extensions:
-        Behat\MinkExtension\ServiceContainer\MinkExtension:
+        Behat\MinkExtension:
             default_session: symfony2

--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -87,7 +87,7 @@ class RestContext extends BaseContext
     {
         $expected = str_replace('\\"', '"', $expected);
         $actual   = $this->request->getContent();
-        $message = "The string '$expected' is not equal to the response of the current page";
+        $message = "Actual response is '$actual', but expected '$expected'";
         $this->assertEquals($expected, $actual, $message);
     }
 
@@ -99,7 +99,7 @@ class RestContext extends BaseContext
     public function theResponseShouldBeEmpty()
     {
         $actual = $this->request->getContent();
-        $message = 'The response of the current page is not empty';
+        $message = "The response of the current page is not empty, it is: $actual";
         $this->assertTrue(null === $actual || "" === $actual, $message);
     }
 
@@ -112,7 +112,7 @@ class RestContext extends BaseContext
     {
         $actual = $this->request->getHttpHeader($name);
         $this->assertEquals(strtolower($value), strtolower($actual),
-            "The header '$name' is equal to '$actual'"
+            "The header '$name' should be equal to '$value', but it is: '$actual'"
         );
     }
 
@@ -131,15 +131,25 @@ class RestContext extends BaseContext
         }
     }
 
+    public function theHeaderShouldBeContains($name, $value)
+    {
+        trigger_error(
+            sprintf('The %s function is deprecated since version 3.1 and will be removed in 4.0. Use the %s::theHeaderShouldContain function instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+        $this->theHeaderShouldContain($name, $value);
+    }
+
     /**
      * Checks, whether the header name contains the given text
      *
      * @Then the header :name should contain :value
      */
-    public function theHeaderShouldBeContains($name, $value)
+    public function theHeaderShouldContain($name, $value)
     {
-        $this->assertContains($value, $this->request->getHttpHeader($name),
-            "The header '$name' doesn't contain '$value'"
+        $actual = $this->request->getHttpHeader($name);
+        $this->assertContains($value, $actual,
+            "The header '$name' should contain value '$value', but actual value is '$actual'"
         );
     }
 
@@ -207,7 +217,7 @@ class RestContext extends BaseContext
             throw new \Exception("The response is not encoded in $encoding");
         }
 
-        $this->theHeaderShouldBeContains('Content-Type', "charset=$encoding");
+        $this->theHeaderShouldContain('Content-Type', "charset=$encoding");
     }
 
     /**

--- a/src/HttpCall/Request/Goutte.php
+++ b/src/HttpCall/Request/Goutte.php
@@ -22,7 +22,16 @@ class Goutte extends BrowserKit
 
     public function setHttpHeader($name, $value)
     {
-        $name = strtoupper("http_$name");
+        /* taken from Behat\Mink\Driver\BrowserKitDriver::setRequestHeader */
+        $contentHeaders = array('CONTENT_LENGTH' => true, 'CONTENT_MD5' => true, 'CONTENT_TYPE' => true);
+        $name = str_replace('-', '_', strtoupper($name));
+
+        // CONTENT_* are not prefixed with HTTP_ in PHP when building $_SERVER
+        if (!isset($contentHeaders[$name])) {
+            $name = 'HTTP_' . $name;
+        }
+        /* taken from Behat\Mink\Driver\BrowserKitDriver::setRequestHeader */
+
         $this->requestHeaders[$name] = $value;
     }
 

--- a/tests/features/rest.feature
+++ b/tests/features/rest.feature
@@ -81,3 +81,20 @@ Feature: Testing RESTContext
         """
         Congratulations, you've correctly set up your apache environment.
         """
+
+    Scenario: Set content headers in POST request
+        When I add "Content-Type" header equal to "xxx"
+        When I send a "POST" request to "rest/index.php" with body:
+        """
+        {"name": "test"}
+        """
+        Then the response should contain ">CONTENT_TYPE : xxx"
+        Then the response should contain ">HTTP_CONTENT_TYPE : xxx"
+
+    Scenario: Content header is clear in different scenario
+        When I send a "POST" request to "rest/index.php" with body:
+        """
+        {"name": "test"}
+        """
+        Then the response should not contain ">CONTENT_TYPE : xxx"
+        Then the response should not contain ">HTTP_CONTENT_TYPE : xxx"


### PR DESCRIPTION
CONTENT_* are not prefixed with HTTP_ in PHP when building $_SERVER
Code taken from Behat\Mink\Driver\BrowserKitDriver::setRequestHeader

Closes #217