### PR TITLE
Fix Mink deprecations

### DIFF
--- a/src/Context/BrowserContext.php
+++ b/src/Context/BrowserContext.php
@@ -82,8 +82,7 @@ class BrowserContext extends BaseContext
      */
     public function iFollowTheNthLink($index, $link)
     {
-        $element = ['link', $this->getSession()->getSelectorsHandler()->xpathLiteral($link)];
-        $node = $this->findElement('named', $element, $index);
+        $node = $this->findElement('named', ['link', $link], $index);
         $node->click();
     }
 
@@ -94,8 +93,7 @@ class BrowserContext extends BaseContext
      */
     public function pressTheNthButton($index, $button)
     {
-        $element = ['button', $this->getSession()->getSelectorsHandler()->xpathLiteral($button)];
-        $node = $this->findElement('named', $element, $index);
+        $node = $this->findElement('named', ['button', $button], $index);
         $node->click();
     }
 


### PR DESCRIPTION
This fixes the following deprecation notices, which are thrown for steps `iFollowTheNthLink` and `pressTheNthButton`:
```
The Behat\Mink\Selector\SelectorsHandler::xpathLiteral method is deprecated as of 1.7 and will be removed in 2.0. Use \Behat\Mink\Selector\Xpath\Escaper::escapeLiteral instead when building Xpath or pass the unescaped value when using the named selector
```
```
Passing an escaped locator to the named selector is deprecated as of 1.7 and will be removed in 2.0. Pass the raw value instead
```