### PR TITLE
Fix Mink 1.7+ deprecations

### DIFF
--- a/src/Context/BaseContext.php
+++ b/src/Context/BaseContext.php
@@ -37,13 +37,13 @@ abstract class BaseContext extends RawMinkContext implements TranslatableContext
             return;
         }
 
-        throw new ExpectationException($errorMessage, $this->getSession());
+        throw new ExpectationException($errorMessage, $this->getSession()->getDriver());
     }
 
     protected function assert($test, $message)
     {
         if ($test === false) {
-            throw new ExpectationException($message, $this->getSession());
+            throw new ExpectationException($message, $this->getSession()->getDriver());
         }
     }
 

--- a/src/Context/BrowserContext.php
+++ b/src/Context/BrowserContext.php
@@ -274,7 +274,7 @@ class BrowserContext extends BaseContext
 
         if ($found === false) {
             $message = "The element '$element' was not found after a $count seconds timeout";
-            throw new ResponseTextException($message, $this->getSession(), $e);
+            throw new ResponseTextException($message, $this->getSession()->getDriver(), $e);
         }
     }
 
@@ -353,7 +353,7 @@ class BrowserContext extends BaseContext
         $obj = $this->getSession()->getPage()->findField($select);
         if ($obj === null) {
             throw new ElementNotFoundException(
-                $this->getSession(), 'select box', 'id|name|label|value', $select
+                $this->getSession()->getDriver(), 'select box', 'id|name|label|value', $select
             );
         }
         $optionText = $obj->getText();


### PR DESCRIPTION
The ExpectationException expects the driver instead of the session since Mink 1.7.

{code}
Passing a Session object to the ExpectationException constructor is deprecated as of Mink 1.7. Pass the driver instead.
{code}