### PR TITLE
[2.x] Add branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,11 @@
 
     "replace": {
         "sanpi/behatch-contexts": "self.version"
+    },
+    
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.8.x-dev"
+        }
     }
 }


### PR DESCRIPTION
To allow to use the `^2.8@dev` notation.