### PR TITLE
[3.x] Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,11 @@
 
     "replace": {
         "sanpi/behatch-contexts": "self.version"
+    },
+    
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
To allow to use the `^3.0@dev` notation.