### PR TITLE
add JSON node should match context

### DIFF
--- a/i18n/en.xliff.dist
+++ b/i18n/en.xliff.dist
@@ -199,6 +199,10 @@
                 <source>the JSON node :node should be equal to :text</source>
                 <target></target>
             </trans-unit>
+            <trans-unit id="the-json-node-should-match">
+                <source>the JSON node :node should match :pattern</source>
+                <target></target>
+            </trans-unit>
             <trans-unit id="the-json-nodes-should-be-equal-to">
                 <source>the JSON nodes should be equal to:</source>
                 <target></target>

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -77,6 +77,24 @@ class JsonContext extends BaseContext
     }
 
     /**
+     * Checks, that given JSON node matches given pattern
+     *
+     * @Then the JSON node :node should match :pattern
+     */
+    public function theJsonNodeShouldMatch($node, $pattern)
+    {
+        $json = $this->getJson();
+
+        $actual = $this->inspector->evaluate($json, $node);
+
+        if (!((bool) preg_match($pattern, $actual))) {
+            throw new \Exception(
+                sprintf("The node value is '%s'", json_encode($actual))
+            );
+        }
+    }
+
+    /**
      * Checks, that given JSON node is null
      *
      * @Then the JSON node :node should be null

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -87,7 +87,7 @@ class JsonContext extends BaseContext
 
         $actual = $this->inspector->evaluate($json, $node);
 
-        if (!((bool) preg_match($pattern, $actual))) {
+        if (preg_match($pattern, $actual) === 0) {
             throw new \Exception(
                 sprintf("The node value is '%s'", json_encode($actual))
             );

--- a/tests/features/json.feature
+++ b/tests/features/json.feature
@@ -28,6 +28,9 @@ Feature: Testing JSONContext
         And the JSON node "numbers[3].complexeshizzle" should be equal to "true"
         And the JSON node "numbers[3].so[0]" should be equal to "very"
         And the JSON node "numbers[3].so[1].complicated" should be equal to "indeed"
+        And the JSON node "numbers[0]" should match "/o.{1}e/"
+        And the JSON node "numbers[1]" should match "/.{2}o/"
+        And the JSON node "numbers[2]" should match "/[a-z]{3}e.+/"
 
         And the JSON nodes should be equal to:
             | foo        | bar   |


### PR DESCRIPTION
Hi,

First, thanks for your work. I was looking for a way to check that a json node matched a pattern and only found the "JSON should be valid according to this schema" way which seemed a little overkill when you only want to test one JSON node. So this should be used to test a single node against a regex.