### PR TITLE
Fixed  #236 - problem with automatic casting of numeric values

### DIFF
--- a/src/Context/BaseContext.php
+++ b/src/Context/BaseContext.php
@@ -27,7 +27,12 @@ abstract class BaseContext extends RawMinkContext implements TranslatableContext
      */
     public function castToInt($count)
     {
-        return intval($count);
+        if (intval($count) < PHP_INT_MAX) {
+
+            return intval($count);
+        }
+
+        return $count;
     }
 
     protected function getMinkContext()

--- a/tests/features/rest.feature
+++ b/tests/features/rest.feature
@@ -56,9 +56,15 @@ Feature: Testing RESTContext
         When I send a GET request to "/rest/index.php"
         Then I should see "HTTP_XXX : yyy"
 
+    Scenario: Add header with large numeric value
+        Given I add "xxx-large-numeric" header equal to "92233720368547758070"
+        When I send a GET request to "/rest/index.php"
+        Then I should see "HTTP_XXX_LARGE_NUMERIC : 92233720368547758070"
+
     Scenario: Header should not be cross-scenarios persistent
         When I send a GET request to "/rest/index.php"
         Then I should not see "HTTP_XXX : yyy"
+        Then I should not see "HTTP_XXX_LARGE_NUMERIC"
 
     Scenario: Case-insensitive header name
         Like describe in the rfc2614 §4.2


### PR DESCRIPTION
The automatic casting of numeric values in the BaseContext class
is limited by the PHP_INT_MAX constant. Any string with an numeric
value larger than PHP_INT_MAX gets automatically casted to an
integer with the value of PHP_INT_MAX.

This could lead to problems, for example when sending a http-header
with a large numeric value.

This workaround checks if the numeric value is equal or larger than
PHP_INT_MAX and does not cast to integer in this case.