### PR TITLE
Add PHP-matcher to contexts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
     - composer install
 
     - test "$DEPS" == "low" || composer update --prefer-lowest
-    - test ${TRAVIS_PHP_VERSION:0:1} -lt 7 || composer update atoum/atoum
+    - test ${TRAVIS_PHP_VERSION:0:1} -lt 7 || composer update atoum/atoum && composer req coduo/php-matcher
 
 script:
     - ./bin/atoum

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
         "fabpot/goutte": "^3.2"
     },
 
+    "suggest": {
+        "coduo/php-matcher": "Allow usage of PHP matcher with the JSON Context"
+    },
+
     "autoload": {
         "psr-4": {
             "Behatch\\": "src/"

--- a/src/Asserter.php
+++ b/src/Asserter.php
@@ -3,6 +3,8 @@
 namespace Behatch;
 
 use Behat\Mink\Exception\ExpectationException;
+use Behatch\Exception\MissingPackageException;
+use Coduo\PHPMatcher\PHPMatcher;
 
 trait Asserter
 {
@@ -96,4 +98,16 @@ trait Asserter
             $this->assertTrue($value);
         }, $message);
     }
+
+	protected function assertMatch($pattern, $actual, $message = null)
+	{
+		if (!class_exists(PHPMatcher::class)) {
+			throw new MissingPackageException('coduo/php-matcher', 'assertMatch');
+		}
+
+		$this->assert(
+			PHPMatcher::match($actual, $pattern, $error),
+			$message ?: "The element '$actual' do not match '$pattern'"
+		);
+	}
 }

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -403,7 +403,41 @@ class JsonContext extends BaseContext
         }, 'JSON Schema matches but it should not');
     }
 
+	/**
+	 * Checks, that given JSON node matches given PHP matcher pattern
+	 *
+	 * @Then the JSON node :node should match php-matcher :pattern
+	 */
+	public function theJsonNodeShouldMatchWithPHPMatcher($node, $pattern)
+	{
+		$json = $this->getJson();
 
+		$actual = $this->inspector->evaluate($json, $node);
+
+		if (preg_match($pattern, $actual) === 0) {
+			throw new \Exception(
+				sprintf("The node value is '%s'", json_encode($actual))
+			);
+		}
+	}
+
+	/**
+	 * Checks, that the JSON response match the given PHP matcher pattern
+	 *
+	 * @Then the JSON should match:
+	 */
+	public function theJsonShouldMatch(PyStringNode $content)
+	{
+		$expected = $content->getRaw();
+		$actual = $this->getJson();
+		// Remove all useless whitespaces
+		$expected = preg_replace('/\s(?=([^"]*"[^"]*")*[^"]*$)/', '', $expected);
+		$this->assertMatch(
+			(string) $expected,
+			(string) $actual,
+			"The json do not match:\n". $actual->encode()
+		);
+	}
 
     protected function getJson()
     {

--- a/src/Exception/MissingPackageException.php
+++ b/src/Exception/MissingPackageException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Behatch\Exception;
+
+final class MissingPackageException extends \RuntimeException
+{
+	public function __construct($package, $method)
+	{
+		parent::__construct("Please install $package composer package in order to use $method method.");
+	}
+
+}

--- a/tests/features/json.feature
+++ b/tests/features/json.feature
@@ -196,3 +196,29 @@ Feature: Testing JSONContext
         Given I am on "/json/swaggerpartial.json"
         Then the response should be in JSON
         And the JSON should not be valid according to swagger "tests/fixtures/www/json/swagger.json" dump schema "sample-invalid-definition"
+
+    @>php7.0
+    Scenario: Json contents validation with php matcher
+        Given I am on "/json/imajson.json"
+        Then the JSON should match:
+            """
+            {
+                "foo": "@string@",
+                "numbers": [
+                    "one",
+                    "two",
+                    "three",
+                    {
+                        "complexeshizzle": @boolean@,
+                        "so": [
+                            "very",
+                            {
+                                "complicated": "@string@"
+                            }
+                        ]
+                    }
+                ]
+            }
+            """
+        And the JSON node "numbers[0]" should match php-matcher "@string@"
+        And the JSON node "numbers[0]" should match php-matcher "@string@.matchRegex('/o.{1}e/')"

--- a/tests/units/Exception/MissingPackageException.php
+++ b/tests/units/Exception/MissingPackageException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Behatch\Tests\Units\Exception;
+
+class MissingPackageException extends \atoum
+{
+	public function test_exception_meesage()
+	{
+		$exception = $this->newTestedInstance('foo', 'bar');
+
+		$this->string($exception->getMessage())
+			->isEqualTo('Please install foo composer package in order to use bar method.');
+	}
+}


### PR DESCRIPTION
Hi,

This PR is an exemple of what I would like to add in this project.

But first of all, I want to discuss on it with you.

The idea is to use https://github.com/coduo/php-matcher with the `JsonContext` (and maybe others).

Sometime, you cannot predict some values of a response. Things like, `uuid`, `date` ...
The idea is to do something like this:

```json
// ...
        "city": {
            "@id": "@string@.startWith('city/')",
            "@type": "City",
            "name": "Lille",
            "zipcode": "59000",
            "createdAt": "@string@.isDateTime()",
            "updatedAt": "@string@.isDateTime()",
        },
// ...
```

I see two differents way of doing it:

1. Update the behavior of `assertSame` and `assertEquals` methods of the `Asserter`.

Devs don't need to update there tests and can directly use it.
But we lost the meaning of the two methods of the Asserter.

2. Create specific steps like `The JSON should match: :pystring` and `The JSON node should match :expression`, ...

Devs need to update there tests to use it.
We keep the assertSame and assertEquals.


What do you think of it @sanpii ?

