### PR TITLE
Add a «More than N elements» and «Less than N elements» in JSON context

### DIFF
--- a/src/Asserter.php
+++ b/src/Asserter.php
@@ -60,6 +60,22 @@ trait Asserter
         );
     }
 
+    protected function assertLessThan($expected, $actual, $message = null)
+    {
+        $this->assert(
+            $expected > $actual,
+            $message ?: "The element '$actual' is not smaller than to '$expected'"
+        );
+    }
+
+    protected function assertMoreThan($expected, $actual, $message = null)
+    {
+        $this->assert(
+            $expected < $actual,
+            $message ?: "The element '$actual' is not greater than to '$expected'"
+        );
+    }
+
     protected function assertSame($expected, $actual, $message = null)
     {
         $this->assert(

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -211,6 +211,34 @@ class JsonContext extends BaseContext
     }
 
     /**
+     * Checks, that given JSON node has less than N element(s)
+     *
+     * @Then the JSON node :node should have less than :count element(s)
+     */
+    public function theJsonNodeShouldHaveLessThanElements($node, $count)
+    {
+        $json = $this->getJson();
+
+        $actual = $this->inspector->evaluate($json, $node);
+
+        $this->assertLessThan($count, sizeof((array) $actual));
+    }
+
+    /**
+     * Checks, that given JSON node has more than N element(s)
+     *
+     * @Then the JSON node :node should have more than :count element(s)
+     */
+    public function theJsonNodeShouldHaveMoreThanElements($node, $count)
+    {
+        $json = $this->getJson();
+
+        $actual = $this->inspector->evaluate($json, $node);
+
+        $this->assertMoreThan($count, sizeof((array) $actual));
+    }
+
+    /**
      * Checks, that given JSON node contains given value
      *
      * @Then the JSON node :node should contain :text

--- a/tests/features/json.feature
+++ b/tests/features/json.feature
@@ -176,6 +176,8 @@ Feature: Testing JSONContext
         Given I am on "/json/notnullvalues.json"
         Then the response should be in JSON
         And the JSON node '' should have 5 elements
+        And the JSON node '' should have more than 4 elements
+        And the JSON node '' should have less than 6 elements
         And the JSON node "one" should not be null
         And the JSON node "one" should be false
         And the JSON node "two" should not be null


### PR DESCRIPTION
Sometimes it can be really usefull, when you don't know exactly how many elements you should get from a JSON, to count elements relatively.

This PR adds a «JSON has more than N elements» and «JSON has less than N elements» feature.