### PR TITLE
Fix parameter name on http files

### DIFF
--- a/src/HttpCall/Request/BrowserKit.php
+++ b/src/HttpCall/Request/BrowserKit.php
@@ -59,9 +59,9 @@ class BrowserKit
 
     public function send($method, $url, $parameters = [], $files = [], $content = null, $headers = [])
     {
-        foreach ($files as $originalName => &$file) {
+        foreach ($files as &$file) {
             if (is_string($file)) {
-                $file = new UploadedFile($file, $originalName);
+                $file = new UploadedFile($file, pathinfo($file, PATHINFO_BASENAME));
             }
         }
 


### PR DESCRIPTION
Hello,

Today I was facing an issue, that I fixed with the code in the PR.

The issue is, that I was not having the same results with an `UploadedFile` object in test and in dev.

For now, I you add a file in your request like this:
```
    When I send a POST request to "/static_translations/import" with parameters:
      | key  | value                           |
      | file   | @my_real_filename.txt |
```
In tests, the property `$uploadedFile->getClientOriginalName()` returns `file`, and `$uploadedFile->getClientOriginalExtension()` returns `null`.

But in dev, same calls returns `my_real_filename.txt` and `txt`.

So my feature works in dev, but does not pass tests ...

This come from the `originalName` of the `UploadedFile` class.

Let me know if this sounds good or bad to you.

Thanks
Kevin