### PR TITLE
Fix json schema to allow relative schemas on Windows.

### DIFF
--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -323,7 +323,7 @@ class JsonContext extends BaseContext
             $this->getJson(),
             new JsonSchema(
                 file_get_contents($filename),
-                'file://' . realpath($filename)
+                'file://' . str_replace(DIRECTORY_SEPARATOR, '/', realpath($filename))
             )
         );
     }


### PR DESCRIPTION
Relative json schemas (i.e. "$ref": "./object.json" ) do not work on Windows due to realpath returning \ and later parsing requires /