### PR TITLE
Catch exception from callable

### DIFF
--- a/src/Asserter.php
+++ b/src/Asserter.php
@@ -12,10 +12,8 @@ trait Asserter
             $callbable();
         }
         catch (\Exception $e) {
-            return;
+            throw new ExpectationException($errorMessage, $this->getSession()->getDriver());
         }
-
-        throw new ExpectationException($errorMessage, $this->getSession()->getDriver());
     }
 
     protected function assert($test, $message)


### PR DESCRIPTION
As noticed in #260 there is an issue when trying to check if a JSON node is null or not.
I'll rather prefer to thow an exception here in order to avoid a "silent" return in a try/catch block.
The PropertyAccessor's getValue() method will throw an `throwInvalidArgumentException` exception in this case.

**Description:**
Given I have the following JSON to test, for example (any valid JSON will do the trick):
```json
{
  "fieldA": "toto",
  "fieldB": "tata"
}
```
And I want to check that "notExistingField" should not be null.
The following step is a **success**: `And the JSON node "notExistingField" should not be null`.
I was doing TDD, and I expected my test to **fail**.

Before I add/update tests, let me know what do you think about it.
Thanks.