### PR TITLE
Check that missing node is not null

### DIFF
--- a/tests/features/json.feature
+++ b/tests/features/json.feature
@@ -48,6 +48,7 @@ Feature: Testing JSONContext
             | foo | something else |
 
         And the JSON node "bar" should not exist
+        And the JSON node "bar" should not be null
 
     Scenario: Json validation with schema
         Given I am on "/json/imajson.json"


### PR DESCRIPTION
I accidentaly wrote this in a test:

```
    And the JSON node "root[0].createdAt" should not be null
    And the JSON node "root[0].createdAt" should not exist
```

The expected behaviour is that the node doesn't exist, but `should not be null` didn't failed.

So I add this test to check if it will fail or not on CI. 