### PR TITLE
Fix HttpCallListener when Mink driver is not started yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable
@@ -44,8 +44,9 @@ matrix:
 before_script:
     - Xvfb $DISPLAY -extension RANDR &> /dev/null &
 
-    - LATEST_CHROMEDRIVER_VERSION=`curl http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
-    - wget --no-verbose https://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER_VERSION/chromedriver_linux64.zip
+    - CHROME_MAIN_VERSION=`google-chrome-stable --version | sed -E 's/(^Google Chrome |\.[0-9]+ )//g'`
+    - CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_MAIN_VERSION"`
+    - wget --no-verbose "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
     - unzip chromedriver_linux64.zip -d ~/bin
 
     - wget "https://selenium-release.storage.googleapis.com/${SELENIUM_VERSION%%.[[:digit:]]}/selenium-server-standalone-${SELENIUM_VERSION}.jar" -O selenium.jar

--- a/src/Context/BrowserContext.php
+++ b/src/Context/BrowserContext.php
@@ -25,7 +25,9 @@ class BrowserContext extends BaseContext
      */
     public function closeBrowser()
     {
-        $this->getSession()->stop();
+        if ($this->getMink()->isSessionStarted()) {
+            $this->getSession()->stop();
+        }
     }
 
     /**

--- a/src/HttpCall/HttpCallListener.php
+++ b/src/HttpCall/HttpCallListener.php
@@ -51,9 +51,11 @@ class HttpCallListener implements EventSubscriberInterface
         // For now to avoid modification on MinkContext
         // We add fallback on Mink
         try {
-            $this->httpCallResultPool->store(
-                new HttpCallResult($this->mink->getSession()->getPage()->getContent())
-            );
+            if ($this->mink->getSession()->isStarted()) {
+                $this->httpCallResultPool->store(
+                    new HttpCallResult($this->mink->getSession()->getPage()->getContent())
+                );
+            }
         } catch (\LogicException $e) {
             // Mink has no response
         } catch (\Behat\Mink\Exception\DriverException $e) {

--- a/tests/features/browser.feature
+++ b/tests/features/browser.feature
@@ -1,8 +1,12 @@
 Feature: Browser Feature
 
+    @javascript
+    Scenario: Testing when scenario has no HTTP call
+        Given I wait 0.1 seconds
+
     # If this scenario fails
     # It's probably because your web environment is not properly setup
-    # You will find the necessery help in README.md
+    # You will find the necessary help in README.md
     @javascript
     Scenario: Testing simple web access
         Given I am on "/index.html"


### PR DESCRIPTION
Fix the following error when BehatchExtension is used with Selenium2 Mink driver : 

`[11-Sep-2020 12:14:21 Europe/Paris] PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function source() on null in /app/vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php:487
Stack trace:
#0 /app/vendor/behat/mink/src/Element/DocumentElement.php(37): Behat\Mink\Driver\Selenium2Driver->getContent()
#1 /app/vendor/behatch/contexts/src/HttpCall/HttpCallListener.php(55): Behat\Mink\Element\DocumentElement->getContent()
#2 /app/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php(184): Behatch\HttpCall\HttpCallListener->afterStep(Object(Behat\Behat\EventDispatcher\Event\AfterStepTested), 'tester.step_tes...', Object(Behat\Testwork\EventDispatcher\TestworkEventDispatcher))
#3 /app/vendor/behat/behat/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php(39): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(Array, 'tester.step_tes...', Object(Behat\Behat\EventDispatcher\Event\AfterStepTested))
#4 /app/vendor/behat/behat/src/Behat/Behat/EventDispatcher/Tester/EventD in /app/vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php on line 487
`

`Behat\Mink\Driver\Selenium2Driver->getContent()` is called whereas the driver hasn't started yet.