### PR TITLE
fix: don't set the Accept header by default

### DIFF
--- a/tests/features/rest.feature
+++ b/tests/features/rest.feature
@@ -97,7 +97,11 @@ Feature: Testing RESTContext
         Congratulations, you've correctly set up your apache environment.
         """
 
-    @>php5.5
+    Scenario: Accept header should not be set by dfault
+      When I send a GET request to "/rest/index.php"
+      Then I should not see "HTTP_ACCEPT"
+
+  @>php5.5
     Scenario: Set content headers in POST request
         When I add "Content-Type" header equal to "xxx"
         When I send a "POST" request to "rest/index.php" with body:

--- a/tests/fixtures/www/rest/index.php
+++ b/tests/fixtures/www/rest/index.php
@@ -18,7 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'PUT' && !empty($body)) {
 You have sent a <?php print $_SERVER['REQUEST_METHOD']; ?> request.
 
 <?php print sizeof($_SERVER); ?> header(s) received.
-<?php foreach($_SERVER as $key => $value): ?>
+<?php foreach(array_filter($_SERVER) as $key => $value): ?>
   <br /><?php print $key ?> : <?php print $value; ?>
 <?php endforeach; ?>
 


### PR DESCRIPTION
This is a workaround for https://github.com/symfony/symfony/issues/33393.

Currently, because of a limitation in Symfony, a default `Accept` HTTP header is always set to `text/html`. This is annoying when testing an API: it's a legit testing use case to ensure that the API behaves properly if this header isn't passed. Until recently, it was possible to use a hack to remove this header (for instance, in API Platform: https://github.com/api-platform/core/blob/master/features/bootstrap/HttpHeaderContext.php#L32), but it doesn't work anymore because Symfony now enforces type parameters.