### PR TITLE
fix browserkit filename

### DIFF
--- a/src/HttpCall/Request/BrowserKit.php
+++ b/src/HttpCall/Request/BrowserKit.php
@@ -59,9 +59,9 @@ class BrowserKit
 
     public function send($method, $url, $parameters = [], $files = [], $content = null, $headers = [])
     {
-        foreach ($files as $originalName => &$file) {
+        foreach ($files as &$file) {
             if (is_string($file)) {
-                $file = new UploadedFile($file, $originalName);
+                $file = new UploadedFile($file, basename($file));
             }
         }
 


### PR DESCRIPTION
In var $originalName we have always key 'file' instead of the file name.