### PR TITLE
Prefer reflection method getType as getClass deprected as of PHP 8.0

### DIFF
--- a/src/HttpCall/HttpCallResultPoolResolver.php
+++ b/src/HttpCall/HttpCallResultPoolResolver.php
@@ -24,6 +24,11 @@ class HttpCallResultPoolResolver implements ArgumentResolver
             $parameters = $constructor->getParameters();
             foreach ($parameters as $parameter) {
                 if (
+                    method_exists($parameter, 'getType')
+                    && isset($this->dependencies[(string) $parameter->getType()])
+                ) {
+                    $arguments[$parameter->name] = $this->dependencies[(string) $parameter->getType()];
+                } elseif (
                     null !== $parameter->getClass()
                     && isset($this->dependencies[$parameter->getClass()->name])
                 ) {


### PR DESCRIPTION
Please consider releasing this quick patch supporting PHP upgrade. Thank you.
## ReflectionParameter::getClass
> Warning This function has been DEPRECATED as of PHP 8.0.0. Relying on this function is highly discouraged.

https://www.php.net/manual/en/reflectionparameter.getclass.php
https://www.php.net/manual/en/reflectionparameter.gettype.php