### PR TITLE
Fix: PHP 8 Support - do not call deprecated ReflectionProperty::getClass

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         "behat/behat": "^3.0.13",
         "friends-of-behat/mink-extension": "^2.3.1",
         "justinrainbow/json-schema": "^5.0",
-        "symfony/property-access": "^2.3|^3.0|^4.0|^5.0",
-        "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0",
-        "symfony/dom-crawler": "^2.4|^3.0|^4.0|^5.0"
+        "symfony/property-access": "^2.3|^3.0|^4.0|^5.0|^6.0",
+        "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0|^6.0",
+        "symfony/dom-crawler": "^2.4|^3.0|^4.0|^5.0|^6.0"
     },
 
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         "behat/behat": "^3.0.13",
         "friends-of-behat/mink-extension": "^2.3.1",
         "justinrainbow/json-schema": "^5.0",
-        "symfony/property-access": "^2.3|^3.0|^4.0|^5.0|^6.0",
-        "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0|^6.0",
-        "symfony/dom-crawler": "^2.4|^3.0|^4.0|^5.0|^6.0"
+        "symfony/property-access": "^2.3|^3.0|^4.0|^5.0|^6.0|^7.0",
+        "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0|^6.0|^7.0",
+        "symfony/dom-crawler": "^2.4|^3.0|^4.0|^5.0|^6.0|^7.0"
     },
 
     "require-dev": {

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -276,6 +276,9 @@ class JsonContext extends BaseContext
         } catch (\Exception $e) {
             throw new \Exception("The node '$name' does not exist.");
         }
+        if (!$node) {
+            throw new \Exception("The node '$name' does not exist.");
+        }
         return $node;
     }
 

--- a/src/HttpCall/HttpCallResultPoolResolver.php
+++ b/src/HttpCall/HttpCallResultPoolResolver.php
@@ -23,14 +23,35 @@ class HttpCallResultPoolResolver implements ArgumentResolver
         if ($constructor !== null) {
             $parameters = $constructor->getParameters();
             foreach ($parameters as $parameter) {
-                if (
-                    null !== $parameter->getClass()
-                    && isset($this->dependencies[$parameter->getClass()->name])
-                ) {
-                    $arguments[$parameter->name] = $this->dependencies[$parameter->getClass()->name];
+                if ($dependency = $this->resolveDependency($parameter)) {
+                    $arguments[$parameter->name] = $dependency;
                 }
             }
         }
         return $arguments;
+    }
+
+    private function resolveDependency(\ReflectionParameter $parameter)
+    {
+        if (method_exists($parameter, 'getType')) {
+            if (
+                ($type = $parameter->getType()) &&
+                !$type->isBuiltin() &&
+                ($name = $type->getName()) &&
+                isset($this->dependencies[$name])
+            ) {
+                return $this->dependencies[$name];
+            }
+            return null;
+        }
+
+        if (
+            null !== $parameter->getClass()
+            && isset($this->dependencies[$parameter->getClass()->name])
+        ) {
+            return $this->dependencies[$parameter->getClass()->name];
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
See also: https://github.com/Behatch/contexts/pull/297

This PR has resolved all my issues in relation to the getClass method being called.

The error was preventing tests from completing or getting any genuine failures from the tests.

I referenced this post for a like-for-like comparison of the methods - https://php.watch/versions/8.0/deprecated-reflectionparameter-methods#getClass