### PR TITLE
Add assertNull method.

### DIFF
--- a/src/Asserter.php
+++ b/src/Asserter.php
@@ -96,4 +96,9 @@ trait Asserter
             $this->assertTrue($value);
         }, $message);
     }
+
+    protected function assertNull($value, $message = 'The value is not null')
+    {
+        $this->assert(null === $value, $message);
+    }
 }

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -105,11 +105,7 @@ class JsonContext extends BaseContext
 
         $actual = $this->inspector->evaluate($json, $node);
 
-        if (null !== $actual) {
-            throw new \Exception(
-                sprintf('The node value is `%s`', json_encode($actual))
-            );
-        }
+        $this->assertNull($actual, sprintf('The node value is `%s`', json_encode($actual)));
     }
 
     /**


### PR DESCRIPTION
I have a Behat context that extends `Behatch\Context\BaseContext`, so I usually use asserters available in the `Behatch\Asserter` trait to simplify my context code.

Today I wanted to assert that a value is null, so I do this:

```php
$this->assertEquals(null, $user->getSignature());
```

Php CS Fixer sees that, thinks it's a PhpUnit test, and changes it to:

```php
$this->assertNull($user->getSignature());
```

But of course, then I get this error:

```
Fatal error: Call to undefined method App\Tests\Behat\Context\UserContext::assertNull()
```

So I propose to add this useful method.